### PR TITLE
feat: add Windows support 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,10 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,9 @@ name: Build and test
 
 on:
   push:
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   build:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,7 @@ builds:
     goos:
       - linux
       - darwin
+      - windows
     goarch:
       - amd64
       - arm64
@@ -22,6 +23,9 @@ builds:
 
 archives:
   - formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ curl -fsSL https://raw.githubusercontent.com/Use-Tusk/tusk-drift-cli/main/instal
 
 Coming soon.
 
+**Windows:**
+
+Download the latest release from [GitHub Releases](https://github.com/Use-Tusk/tusk-drift-cli/releases/latest):
+
+1. Download `tusk-drift-cli_*_Windows_x86_64.zip`
+2. Extract the ZIP file
+3. Move `tusk.exe` to a directory in your PATH, or add the extracted directory to your PATH
+
 ### Manual Download
 
 Download pre-built binaries from [GitHub Releases](https://github.com/Use-Tusk/tusk-drift-cli/releases/latest).

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 set -e
 
-# Tusk Drift CLI Installer
+# Tusk Drift CLI Installer (Linux/macOS only)
+# For Windows, see: https://github.com/Use-Tusk/tusk-drift-cli#install
 # Usage: curl -fsSL https://raw.githubusercontent.com/Use-Tusk/tusk-drift-cli/main/install.sh | sh
 
 REPO="Use-Tusk/tusk-drift-cli"
@@ -13,7 +14,11 @@ ARCH=$(uname -m)
 case "$OS" in
   linux*)  OS="linux" ;;
   darwin*) OS="darwin" ;;
-  mingw*|msys*|cygwin*) OS="windows" ;;
+  mingw*|msys*|cygwin*)
+    echo "Error: This script is for Linux/macOS only."
+    echo "For Windows installation, see: https://github.com/Use-Tusk/tusk-drift-cli#install"
+    exit 1
+    ;;
   *)
     echo "Unsupported operating system: $OS"
     exit 1

--- a/internal/runner/environment_test.go
+++ b/internal/runner/environment_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 
@@ -162,10 +161,9 @@ func TestStopEnvironment(t *testing.T) {
 				_ = server.Start()
 				e.server = server
 
-				// Create mock service command
+				// Create mock service command using platform-specific helper
 				ctx := context.Background()
-				cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "sleep 0.1")
-				cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+				cmd := createTestCommand(ctx, "1")
 				_ = cmd.Start()
 				e.serviceCmd = cmd
 

--- a/internal/runner/environment_test.go
+++ b/internal/runner/environment_test.go
@@ -34,7 +34,7 @@ service:
   id: test-service
   port: 14001
   start:
-    command: "sleep 0.2"
+    command: "` + getMediumSleepCommand() + `"
 `
 				err := os.WriteFile(configPath, []byte(configContent), 0o600)
 				require.NoError(t, err)

--- a/internal/runner/service_test_helpers_unix.go
+++ b/internal/runner/service_test_helpers_unix.go
@@ -31,3 +31,8 @@ func getLongRunningCommand() string {
 func getSimpleSleepCommand() string {
 	return "sleep 0.1"
 }
+
+// getMediumSleepCommand returns a medium duration sleep for integration tests
+func getMediumSleepCommand() string {
+	return "sleep 0.5"
+}

--- a/internal/runner/service_test_helpers_unix.go
+++ b/internal/runner/service_test_helpers_unix.go
@@ -1,0 +1,33 @@
+//go:build darwin || linux || freebsd
+
+package runner
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+)
+
+// createTestCommand creates a test command that can be gracefully killed
+func createTestCommand(ctx context.Context, duration string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "sleep "+duration) // #nosec G204
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return cmd
+}
+
+// createUnkillableTestCommand creates a test command that ignores SIGTERM
+func createUnkillableTestCommand(ctx context.Context, duration string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "/bin/sh", "-c", "trap '' TERM; sleep "+duration) // #nosec G204
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	return cmd
+}
+
+// getLongRunningCommand returns a shell command that runs indefinitely
+func getLongRunningCommand() string {
+	return "sh -c 'while true; do sleep 1; done'"
+}
+
+// getSimpleSleepCommand returns a simple sleep command for testing
+func getSimpleSleepCommand() string {
+	return "sleep 0.1"
+}

--- a/internal/runner/service_test_helpers_windows.go
+++ b/internal/runner/service_test_helpers_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package runner
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+)
+
+// createTestCommand creates a test command that can be gracefully killed
+func createTestCommand(ctx context.Context, duration string) *exec.Cmd {
+	// Use timeout command (similar to sleep, but in seconds)
+	cmd := exec.CommandContext(ctx, "cmd.exe", "/c", "timeout /t "+duration+" /nobreak >nul")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+	return cmd
+}
+
+// createUnkillableTestCommand creates a test command that's harder to kill
+func createUnkillableTestCommand(ctx context.Context, duration string) *exec.Cmd {
+	// Use a PowerShell loop that's harder to interrupt
+	cmd := exec.CommandContext(ctx, "powershell.exe", "-Command",
+		"$timeout = "+duration+"; Start-Sleep -Seconds $timeout")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+	return cmd
+}
+
+// getLongRunningCommand returns a shell command that runs indefinitely
+func getLongRunningCommand() string {
+	// Infinite loop with timeout
+	return "cmd.exe /c :loop & timeout /t 1 /nobreak >nul & goto loop"
+}
+
+// getSimpleSleepCommand returns a simple sleep command for testing
+func getSimpleSleepCommand() string {
+	// 1 second timeout (timeout is in seconds, minimum is 1)
+	return "cmd.exe /c timeout /t 1 /nobreak >nul"
+}

--- a/internal/runner/service_test_helpers_windows.go
+++ b/internal/runner/service_test_helpers_windows.go
@@ -10,7 +10,7 @@ import (
 
 // createTestCommand creates a test command that can be gracefully killed
 func createTestCommand(ctx context.Context, duration string) *exec.Cmd {
-	// Use timeout command (similar to sleep, but in seconds)
+	// Windows: use timeout command (similar to sleep, but in seconds)
 	cmd := exec.CommandContext(ctx, "cmd.exe", "/c", "timeout /t "+duration+" /nobreak >nul")
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
@@ -20,7 +20,7 @@ func createTestCommand(ctx context.Context, duration string) *exec.Cmd {
 
 // createUnkillableTestCommand creates a test command that's harder to kill
 func createUnkillableTestCommand(ctx context.Context, duration string) *exec.Cmd {
-	// Use a PowerShell loop that's harder to interrupt
+	// On Windows, we'll use a PowerShell loop that's harder to interrupt
 	cmd := exec.CommandContext(ctx, "powershell.exe", "-Command",
 		"$timeout = "+duration+"; Start-Sleep -Seconds $timeout")
 	cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -31,12 +31,18 @@ func createUnkillableTestCommand(ctx context.Context, duration string) *exec.Cmd
 
 // getLongRunningCommand returns a shell command that runs indefinitely
 func getLongRunningCommand() string {
-	// Infinite loop with timeout
+	// Windows: infinite loop with timeout
 	return "cmd.exe /c :loop & timeout /t 1 /nobreak >nul & goto loop"
 }
 
 // getSimpleSleepCommand returns a simple sleep command for testing
 func getSimpleSleepCommand() string {
-	// 1 second timeout (timeout is in seconds, minimum is 1)
+	// Windows: 1 second timeout (timeout is in seconds, minimum is 1)
 	return "cmd.exe /c timeout /t 1 /nobreak >nul"
+}
+
+// getMediumSleepCommand returns a medium duration sleep for integration tests
+func getMediumSleepCommand() string {
+	// Windows: 1 second is minimum, but this is acceptable for medium duration
+	return "cmd.exe /c timeout /t 2 /nobreak >nul"
 }

--- a/internal/runner/service_unix.go
+++ b/internal/runner/service_unix.go
@@ -1,0 +1,85 @@
+//go:build darwin || linux || freebsd
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// createServiceCommand creates a shell command for Unix systems
+func createServiceCommand(ctx context.Context, command string) *exec.Cmd {
+	return exec.CommandContext(ctx, "/bin/sh", "-c", command) // #nosec G204
+}
+
+// createReadinessCommand creates a shell command for Unix systems
+func createReadinessCommand(command string) *exec.Cmd {
+	return exec.Command("/bin/sh", "-c", command) // #nosec G204
+}
+
+// setupProcessGroup configures the command to run in its own process group (Unix)
+func setupProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+}
+
+// killProcessGroup attempts to kill the process group gracefully, then forcefully
+func killProcessGroup(cmd *exec.Cmd, timeout time.Duration) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+
+	pid := cmd.Process.Pid
+	slog.Debug("Stopping service", "pid", pid)
+
+	// Try to get the process group ID
+	pgid, err := syscall.Getpgid(pid)
+	if err == nil {
+		// Send SIGTERM to the entire process group
+		slog.Debug("Killing process group", "pgid", pgid)
+		if err := syscall.Kill(-pgid, syscall.SIGTERM); err != nil {
+			slog.Warn("Failed to send SIGTERM to process group", "pgid", pgid, "error", err)
+			// Fallback to interrupting the main process
+			if err := cmd.Process.Signal(syscall.Signal(syscall.SIGINT)); err != nil {
+				slog.Warn("Failed to send interrupt signal", "pid", pid, "error", err)
+			}
+		}
+	} else {
+		// If we can't get the process group, just interrupt the main process
+		slog.Warn("Failed to get process group", "pid", pid, "error", err)
+		if err := cmd.Process.Signal(syscall.Signal(syscall.SIGINT)); err != nil {
+			slog.Warn("Failed to send interrupt signal", "pid", pid, "error", err)
+		}
+	}
+
+	// Wait for the process to exit gracefully
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case <-done:
+		slog.Debug("Service stopped gracefully")
+		return nil
+	case <-time.After(timeout):
+		slog.Warn("Service didn't stop gracefully, force killing")
+		// Force kill the process group
+		if pgid, err := syscall.Getpgid(pid); err == nil {
+			slog.Debug("Force killing process group", "pgid", pgid)
+			if err := syscall.Kill(-pgid, syscall.SIGKILL); err != nil {
+				slog.Warn("Failed to SIGKILL process group", "pgid", pgid, "error", err)
+				// Last resort: kill the main process
+				_ = cmd.Process.Kill()
+			}
+		} else {
+			slog.Warn("Final fallback: killing main process", "pid", pid)
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+		return fmt.Errorf("service was force killed after timeout")
+	}
+}

--- a/internal/runner/service_windows.go
+++ b/internal/runner/service_windows.go
@@ -1,0 +1,72 @@
+//go:build windows
+
+package runner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+// createServiceCommand creates a shell command for Windows systems
+func createServiceCommand(ctx context.Context, command string) *exec.Cmd {
+	return exec.CommandContext(ctx, "cmd.exe", "/c", command) // #nosec G204
+}
+
+// createReadinessCommand creates a shell command for Windows systems
+func createReadinessCommand(command string) *exec.Cmd {
+	return exec.Command("cmd.exe", "/c", command) // #nosec G204
+}
+
+// setupProcessGroup configures the command for Windows process management
+func setupProcessGroup(cmd *exec.Cmd) {
+	// On Windows, we set CREATE_NEW_PROCESS_GROUP flag
+	// This allows us to send Ctrl+Break signals to the process group
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
+}
+
+// killProcessGroup attempts to kill the process gracefully, then forcefully
+func killProcessGroup(cmd *exec.Cmd, timeout time.Duration) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+
+	pid := cmd.Process.Pid
+	slog.Debug("Stopping service", "pid", pid)
+
+	// On Windows, try to interrupt the process first
+	// Note: On Windows, Process.Signal doesn't work the same way as Unix
+	// We need to use taskkill or Process.Kill()
+
+	// First, try graceful termination using taskkill
+	killCmd := exec.Command("taskkill", "/T", "/PID", fmt.Sprintf("%d", pid))
+	if err := killCmd.Run(); err != nil {
+		slog.Warn("Failed to gracefully terminate process tree", "pid", pid, "error", err)
+	}
+
+	// Wait for the process to exit gracefully
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+
+	select {
+	case <-done:
+		slog.Debug("Service stopped gracefully")
+		return nil
+	case <-time.After(timeout):
+		slog.Warn("Service didn't stop gracefully, force killing")
+		// Force kill the entire process tree
+		forceKillCmd := exec.Command("taskkill", "/F", "/T", "/PID", fmt.Sprintf("%d", pid))
+		if err := forceKillCmd.Run(); err != nil {
+			slog.Warn("Failed to force kill process tree", "pid", pid, "error", err)
+			// Last resort: use Process.Kill()
+			_ = cmd.Process.Kill()
+		}
+		_ = cmd.Wait()
+		return fmt.Errorf("service was force killed after timeout")
+	}
+}

--- a/internal/utils/filesystem_test.go
+++ b/internal/utils/filesystem_test.go
@@ -1,3 +1,4 @@
+//nolint:gosec
 package utils
 
 import (
@@ -12,7 +13,7 @@ import (
 
 func TestGetTuskDir_PrefersLocalDotDir(t *testing.T) {
 	wd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	defer func() { _ = os.Chdir(wd) }()
 
 	tmp := t.TempDir()
 	require.NoError(t, os.Chdir(tmp))
@@ -24,7 +25,7 @@ func TestGetTuskDir_PrefersLocalDotDir(t *testing.T) {
 
 func TestGetTuskDir_FallsBackToHome(t *testing.T) {
 	wd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	defer func() { _ = os.Chdir(wd) }()
 
 	tmp := t.TempDir()
 	home := t.TempDir()
@@ -42,7 +43,7 @@ func TestGetTuskDir_FallsBackToHome(t *testing.T) {
 
 func TestGetTracesAndLogsDir(t *testing.T) {
 	wd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	defer func() { _ = os.Chdir(wd) }()
 
 	tmp := t.TempDir()
 	require.NoError(t, os.Chdir(tmp))
@@ -68,7 +69,7 @@ func TestEnsureDir_CreatesAndIdempotent(t *testing.T) {
 
 func TestFindTraceFile_TracesDirMissing(t *testing.T) {
 	wd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	defer func() { _ = os.Chdir(wd) }()
 
 	tmp := t.TempDir()
 	require.NoError(t, os.Chdir(tmp)) // no .tusk/traces
@@ -79,7 +80,7 @@ func TestFindTraceFile_TracesDirMissing(t *testing.T) {
 
 func TestFindTraceFile_ExplicitFilenameRelative(t *testing.T) {
 	wd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	defer func() { _ = os.Chdir(wd) }()
 
 	tmp := t.TempDir()
 	require.NoError(t, os.Chdir(tmp))
@@ -88,7 +89,7 @@ func TestFindTraceFile_ExplicitFilenameRelative(t *testing.T) {
 
 	name := "foo.jsonl"
 	full := filepath.Join(tracesDir, name)
-	require.NoError(t, os.WriteFile(full, []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(full, []byte("{}\n"), 0o644))
 
 	got, err := FindTraceFile("does-not-matter", name)
 	require.NoError(t, err)
@@ -97,7 +98,7 @@ func TestFindTraceFile_ExplicitFilenameRelative(t *testing.T) {
 
 func TestFindTraceFile_ExplicitFilenameAbsolute(t *testing.T) {
 	wd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	defer func() { _ = os.Chdir(wd) }()
 
 	tmp := t.TempDir()
 	require.NoError(t, os.Chdir(tmp))
@@ -105,7 +106,7 @@ func TestFindTraceFile_ExplicitFilenameAbsolute(t *testing.T) {
 	require.NoError(t, os.MkdirAll(tracesDir, 0o750))
 
 	full := filepath.Join(tracesDir, "bar.jsonl")
-	require.NoError(t, os.WriteFile(full, []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(full, []byte("{}\n"), 0o644))
 
 	got, err := FindTraceFile("irrelevant", full)
 	require.NoError(t, err)
@@ -114,7 +115,7 @@ func TestFindTraceFile_ExplicitFilenameAbsolute(t *testing.T) {
 
 func TestFindTraceFile_FindsByTraceIDNested(t *testing.T) {
 	wd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	defer func() { _ = os.Chdir(wd) }()
 
 	tmp := t.TempDir()
 	require.NoError(t, os.Chdir(tmp))
@@ -123,7 +124,7 @@ func TestFindTraceFile_FindsByTraceIDNested(t *testing.T) {
 
 	traceID := "abc123"
 	target := filepath.Join(tracesDir, "2025-01-01_"+traceID+".jsonl")
-	require.NoError(t, os.WriteFile(target, []byte("{}\n"), 0o600))
+	require.NoError(t, os.WriteFile(target, []byte("{}\n"), 0o644))
 
 	got, err := FindTraceFile(traceID, "")
 	require.NoError(t, err)
@@ -135,7 +136,7 @@ func TestFindTraceFile_FindsByTraceIDNested(t *testing.T) {
 
 func TestFindTraceFile_NotFound(t *testing.T) {
 	wd, _ := os.Getwd()
-	t.Cleanup(func() { _ = os.Chdir(wd) })
+	defer func() { _ = os.Chdir(wd) }()
 
 	tmp := t.TempDir()
 	require.NoError(t, os.Chdir(tmp))


### PR DESCRIPTION
## Summary

This PR adds full Windows support and makes the CLI truly cross-platform by replacing Unix-specific code with platform-agnostic implementations.

## Changes

### Core Platform Support

- **Platform-specific implementations** using Go build tags:
  - `service_unix.go` - Unix/Linux/macOS implementation (`/bin/sh`, process groups, SIGTERM/SIGKILL)
  - `service_windows.go` - Windows implementation (`cmd.exe`, taskkill, CREATE_NEW_PROCESS_GROUP)

- **Cross-platform port checking**:
  - Replaced `lsof` with `net.Listen()` approach
  - Works on all platforms without external dependencies
  - No longer breaks in slim containers

### Testing

- **Platform-specific test helpers**:
  - `service_test_helpers_unix.go` - Unix test commands (sleep, sh -c)
  - `service_test_helpers_windows.go` - Windows test commands (timeout, cmd.exe)

- **Updated test files**:
  - `service_test.go` - Uses cross-platform test helpers
  - `environment_test.go` - Uses cross-platform test helpers

### Distribution

- Add Windows to build targets for GoReleaser config