### PR TITLE
fix: test failure classification for MOCK_NOT_FOUND

### DIFF
--- a/internal/runner/executor.go
+++ b/internal/runner/executor.go
@@ -107,6 +107,11 @@ func (e *Executor) GetConcurrency() int {
 	return e.parallel
 }
 
+// GetServer returns the server instance
+func (e *Executor) GetServer() *Server {
+	return e.server
+}
+
 // WaitForSpanData blocks briefly until inbound or match events are recorded for a test
 func (e *Executor) WaitForSpanData(traceID string, timeout time.Duration) {
 	if e.server != nil {


### PR DESCRIPTION
### Summary

When a mock is not found during replay, the SDK throws an error and the service returns an error response (e.g., 500). Previously, this was incorrectly categorized as `RESPONSE_MISMATCH` since the response body differed from expected. This PR fixes the classification to correctly identify and display mock-not-found failures.

### Changes

- Track mock-not-found events in CLI server when SDK requests fail
- Prioritize `MOCK_NOT_FOUND` failure reason over `RESPONSE_MISMATCH` for results sent to Tusk backend
- Update TUI to display mock-not-found details (package, operation, stack trace) instead of response deviations
- Add `GetServer()` method to executor for accessing server state