### PR TITLE
feat: Add Levenshtein based similarity scoring for schema level mock matching

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Use-Tusk/tusk-drift-cli
 go 1.25.0
 
 require (
-	github.com/Use-Tusk/tusk-drift-schemas v0.0.0-20250927035852-0ec6a0206ee5
+	github.com/Use-Tusk/tusk-drift-schemas v0.1.9
 	github.com/agnivade/levenshtein v1.0.3
 	github.com/atotto/clipboard v0.1.4
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,7 @@
-github.com/Use-Tusk/tusk-drift-schemas v0.0.0-20250927035852-0ec6a0206ee5 h1:T6Wypc87oxt4o9kMJ0OwSJY0PaM4Rcz07xCntVxjaws=
-github.com/Use-Tusk/tusk-drift-schemas v0.0.0-20250927035852-0ec6a0206ee5/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
+github.com/Use-Tusk/tusk-drift-schemas v0.1.9 h1:4Nip89mKARfngvo6rgKEBhdtApJrZP9Z0Ltq4oGhwGk=
+github.com/Use-Tusk/tusk-drift-schemas v0.1.9/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
 github.com/agnivade/levenshtein v1.0.3 h1:M5ZnqLOoZR8ygVq0FfkXsNOKzMCk0xRiow0R5+5VkQ0=
 github.com/agnivade/levenshtein v1.0.3/go.mod h1:4SFRZbbXWLF4MU1T9Qg0pGgH3Pjs+t6ie5efyrwRJXs=
-github.com/agnivade/levenshtein v1.2.1 h1:EHBY3UOn1gwdy/VbFwgo4cxecRznFk7fKWN1KOX7eoM=
-github.com/agnivade/levenshtein v1.2.1/go.mod h1:QVVI16kDrtSuwcpd0p1+xMC6Z/VfhtCyDIjcwga4/DU=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=
 github.com/alecthomas/assert/v2 v2.7.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.14.0 h1:R3+wzpnUArGcQz7fCETQBzO5n9IMNi13iIs46aU4V9E=
@@ -47,8 +45,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgryski/trifles v0.0.0-20190318185328-a8d75aae118c h1:TUuUh0Xgj97tLMNtWtNvI9mIV6isjEb9lBMNv+77IGM=
 github.com/dgryski/trifles v0.0.0-20190318185328-a8d75aae118c/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
-github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7cNTs5R6Hk4V2lcmLz2NsG2VnInyNo=
-github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=


### PR DESCRIPTION
## Summary

This PR improves mock matching accuracy when multiple spans match on schema by implementing Levenshtein distance-based similarity scoring. Instead of picking the first/oldest match, the matcher now selects the
most semantically similar mock.

## Problem

When multiple mocks share the same schema (e.g., SQL queries to the same table), the previous implementation would pick the oldest span regardless of content similarity.

Example: A UPDATE users request could incorrectly match an older SELECT FROM teams query just because they shared the same schema and the SELECT was older.

## Solution

Implemented recursive Levenshtein distance based similarity scoring that:
- Activates only when multiple spans match on schema (Priorities 5-8)
- Recursively compares input values (maps, arrays, strings, primitives) up to depth 5
  - After 5, the rest of the depths are stringified and Levenshtein difference is calculated for the string  
- Returns normalized scores between 0.0 and 1.0 (higher = more similar)
- Limits to first 50 candidates for performance
- Uses timestamp as tiebreaker when scores are identical

### Updated Matching Functions
- Modified schema matching functions (Priorities 5-8) to use similarity scoring when multiple candidates exist
- Modified match descriptions to include the top 2 scores. e.g. "Unused span by input schema hash (similarity: 0.95, next best: 0.72)"
- Store top 5 candidates on `spanMatchResult`

## Dependencies
- Added github.com/agnivade/levenshtein@v1.0.3 (pinned to v1.0.3 for unlimited string size support, see details [here](https://github.com/agnivade/levenshtein?tab=readme-ov-file#limitation))

## Testing
- Added 3 tests covering: closest match selection, timestamp tiebreaking, and nested structure comparison

## Performance
- Only activates when multiple schema matches exist
- Limited to getting Levenshtein distance from max 50 candidates
- Max recursion depth of 5