### PR TITLE
fix: upload span result with no match + correct timestamp

### DIFF
--- a/internal/runner/results_upload.go
+++ b/internal/runner/results_upload.go
@@ -224,7 +224,6 @@ func BuildTraceTestResultsProto(e *Executor, results []TestResult, tests []Test)
 			for i := range mockNotFoundEvents {
 				ev := mockNotFoundEvents[i]
 				spanRes := &backend.TraceTestSpanResult{
-					// NO MatchedSpanRecordingId - this is the key difference!
 					MatchedSpanRecordingId: nil,
 					MatchLevel:             nil,
 				}

--- a/internal/runner/results_upload.go
+++ b/internal/runner/results_upload.go
@@ -218,6 +218,24 @@ func BuildTraceTestResultsProto(e *Executor, results []TestResult, tests []Test)
 				}
 				tr.SpanResults = append(tr.SpanResults, spanRes)
 			}
+
+			// Mock-not-found events (outbound requests that had no matching recording)
+			mockNotFoundEvents := e.server.GetMockNotFoundEvents(r.TestID)
+			for i := range mockNotFoundEvents {
+				ev := mockNotFoundEvents[i]
+				spanRes := &backend.TraceTestSpanResult{
+					// NO MatchedSpanRecordingId - this is the key difference!
+					MatchedSpanRecordingId: nil,
+					MatchLevel:             nil,
+				}
+				if ev.StackTrace != "" {
+					spanRes.StackTrace = &ev.StackTrace
+				}
+				if ev.ReplaySpan != nil {
+					spanRes.ReplaySpan = ev.ReplaySpan
+				}
+				tr.SpanResults = append(tr.SpanResults, spanRes)
+			}
 		}
 
 		out = append(out, tr)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds span results for mock-not-found outbound requests (including stack trace and replay span) and normalizes replay span timestamps.
> 
> - **Results Upload (`internal/runner/results_upload.go`)**:
>   - Add span results for mock-not-found events via `server.GetMockNotFoundEvents`, producing entries with `matched_span_recording_id` and `match_level` unset, and propagating `stack_trace`/`replay_span`.
> - **Server (`internal/runner/server.go`)**:
>   - Extend `MockNotFoundEvent` to include `replay_span`; record it when no mock is found.
>   - Normalize timestamps during replay: set `inbound` and `outbound` span timestamps to `timestamppb.Now()`.
> - **Tests (`internal/runner/results_upload_test.go`)**:
>   - Add assertions for mock-not-found span results and inclusion of `replay_span`/`stack_trace`; import `core` for constructing spans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a2e8539f3a899a8eb91a817de15e4657c489489. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->