### PR TITLE
test: fix flaky `TestStartEnvironment` by reducing SDK connection delay

### DIFF
--- a/internal/runner/environment_test.go
+++ b/internal/runner/environment_test.go
@@ -51,7 +51,6 @@ service:
 					// Wait for server to be created
 					for range 50 {
 						if e.server != nil {
-							time.Sleep(100 * time.Millisecond)
 							// Simulate SDK connection
 							e.server.mu.Lock()
 							if !e.server.sdkConnected {
@@ -61,7 +60,7 @@ service:
 							e.server.mu.Unlock()
 							break
 						}
-						time.Sleep(100 * time.Millisecond)
+						time.Sleep(10 * time.Millisecond)
 					}
 				}()
 


### PR DESCRIPTION
Fixes flaky test failure in `TestStartEnvironment/successful_start_all_components_with_mock_sdk`.

**Root Cause:**

The test goroutine had two 100ms sleeps:
1. Polling for server creation (every 100ms)
2. Unnecessary delay after finding the server

This caused the SDK connection to be established after ~200ms, but `WaitForSDKAcknowledgement()` only started at ~110ms with a 100ms timeout, making the timing too tight.

**Changes:**
- Remove unnecessary 100ms sleep after detecting server
- Reduce polling interval from 100ms to 10ms for faster detection
- SDK now connects immediately when server is ready

This provides a comfortable timing margin while keeping the 100ms test timeout.