### PR TITLE
fix: remove timestamp override logic from replay span handling

### DIFF
--- a/internal/runner/server.go
+++ b/internal/runner/server.go
@@ -26,7 +26,6 @@ import (
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Server handles Unix socket communication with the SDK
@@ -509,8 +508,6 @@ func (ms *Server) handleInboundReplaySpanProtobuf(msg *core.SDKMessage, conn net
 	slog.Debug("Received inbound span for replay", "traceID", req.Span.TraceId, "spanID", req.Span.SpanId)
 
 	span := req.Span
-	// Override the timestamp to current replay time (SDK may send wrong timestamp due to Date patching)
-	span.Timestamp = timestamppb.Now()
 
 	ms.mu.Lock()
 	if ms.replayInbound == nil {
@@ -536,11 +533,6 @@ func (ms *Server) findMock(req *core.GetMockRequest) *core.GetMockResponse {
 		testID = ms.currentTestID
 	}
 	ms.mu.RUnlock()
-
-	// Override the timestamp to current replay time (SDK may send wrong timestamp due to Date patching)
-	if req.OutboundSpan != nil {
-		req.OutboundSpan.Timestamp = timestamppb.Now()
-	}
 
 	matcher := NewMockMatcher(ms)
 	var span *core.Span


### PR DESCRIPTION
The CLI was previously overriding span timestamps during replay to work around SDK issues where Date patching could cause incorrect timestamps to be sent. This workaround is no longer needed as the SDK now correctly handles timestamp generation during replay.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops overriding span timestamps during replay and mock lookup, removing the redundant timestamppb dependency.
> 
> - **Runner (`internal/runner/server.go`)**:
>   - **Replay handling**: Remove overriding of `span.Timestamp` in `handleInboundReplaySpanProtobuf`.
>   - **Mock matching**: Remove overriding of `req.OutboundSpan.Timestamp` in `findMock`.
>   - **Imports**: Drop `timestamppb` import no longer needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 934c9dbe2d9252b9fba0d751346c5e7954752c9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->