### PR TITLE
fix: pre-app-start span loading in `list` view, refactor suite span logic

### DIFF
--- a/internal/runner/suite_spans.go
+++ b/internal/runner/suite_spans.go
@@ -1,0 +1,245 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+
+	"github.com/Use-Tusk/tusk-drift-cli/internal/api"
+	"github.com/Use-Tusk/tusk-drift-cli/internal/logging"
+	"github.com/Use-Tusk/tusk-drift-cli/internal/utils"
+	backend "github.com/Use-Tusk/tusk-drift-schemas/generated/go/backend"
+	core "github.com/Use-Tusk/tusk-drift-schemas/generated/go/core"
+)
+
+// SuiteSpanOptions contains options for building suite spans
+type SuiteSpanOptions struct {
+	// Cloud options
+	IsCloudMode bool
+	Client      *api.TuskClient
+	AuthOptions api.AuthOptions
+	ServiceID   string
+	TraceTestID string // If set, fetch all suite spans for cross-suite matching
+
+	// Local options
+	AllTests    []Test // All tests loaded (for extracting spans)
+	Interactive bool   // Whether to log errors interactively
+}
+
+// BuildSuiteSpansForRun builds the suite spans for the run.
+// If running a single cloud trace test, eager-fetch all suite spans to enable cross-suite matching.
+// Returns the suite spans, the number of pre-app-start spans, and the number of unique traces.
+func BuildSuiteSpansForRun(
+	ctx context.Context,
+	opts SuiteSpanOptions,
+	currentTests []Test,
+) ([]*core.Span, int, int, error) {
+	var suiteSpans []*core.Span
+
+	// If running a single cloud trace test, fetch all suite spans
+	if opts.IsCloudMode && opts.Client != nil && opts.TraceTestID != "" {
+		all, err := fetchAllSuiteSpans(ctx, opts.Client, opts.AuthOptions, opts.ServiceID)
+		if err != nil {
+			return nil, 0, 0, fmt.Errorf("fetch all suite spans: %w", err)
+		}
+		if len(all) > 0 {
+			suiteSpans = append(suiteSpans, all...)
+		}
+	}
+
+	// Fallback: use spans from the loaded tests
+	if len(suiteSpans) == 0 {
+		// Prefer all tests if available (for list view with all tests loaded)
+		testsToUse := currentTests
+		if len(opts.AllTests) > 0 {
+			testsToUse = opts.AllTests
+		}
+
+		for _, t := range testsToUse {
+			if len(t.Spans) > 0 {
+				suiteSpans = append(suiteSpans, t.Spans...)
+			}
+		}
+	}
+
+	// Layer on pre-app-start spans if available
+	// Prepend these spans so they get considered first
+	if opts.IsCloudMode && opts.Client != nil {
+		preAppStartSpans, err := FetchPreAppStartSpansFromCloud(ctx, opts.Client, opts.AuthOptions, opts.ServiceID)
+		if err == nil && len(preAppStartSpans) > 0 {
+			suiteSpans = append(preAppStartSpans, suiteSpans...)
+		}
+	} else {
+		if localPreAppStartSpans, err := FetchLocalPreAppStartSpans(opts.Interactive); err == nil && len(localPreAppStartSpans) > 0 {
+			suiteSpans = append(localPreAppStartSpans, suiteSpans...)
+		}
+	}
+
+	suiteSpans = DedupeSpans(suiteSpans)
+
+	preAppCount := 0
+	uniq := make(map[string]struct{})
+	for _, s := range suiteSpans {
+		if s == nil {
+			continue
+		}
+		if s.IsPreAppStart {
+			preAppCount++
+		}
+		if s.TraceId != "" {
+			uniq[s.TraceId] = struct{}{}
+		}
+	}
+
+	return suiteSpans, preAppCount, len(uniq), nil
+}
+
+// PrepareAndSetSuiteSpans is a convenience function that builds suite spans and sets them on the executor
+func PrepareAndSetSuiteSpans(
+	ctx context.Context,
+	exec *Executor,
+	opts SuiteSpanOptions,
+	currentTests []Test,
+) error {
+	suiteSpans, preAppCount, uniqueTraceCount, err := BuildSuiteSpansForRun(ctx, opts, currentTests)
+	if opts.Interactive {
+		logging.LogToService(fmt.Sprintf(
+			"Loading %d suite spans for matching (%d unique traces, %d pre-app-start)",
+			len(suiteSpans), uniqueTraceCount, preAppCount,
+		))
+	}
+	slog.Debug("Prepared suite spans for matching",
+		"count", len(suiteSpans),
+		"uniqueTraces", uniqueTraceCount,
+		"preAppSpans", preAppCount,
+		"interactive", opts.Interactive,
+		"traceTestID", opts.TraceTestID,
+	)
+	exec.SetSuiteSpans(suiteSpans)
+	return err
+}
+
+// FetchPreAppStartSpansFromCloud fetches pre-app-start spans from the cloud backend
+func FetchPreAppStartSpansFromCloud(
+	ctx context.Context,
+	client *api.TuskClient,
+	auth api.AuthOptions,
+	serviceID string,
+) ([]*core.Span, error) {
+	var all []*core.Span
+	cur := ""
+	for {
+		req := &backend.GetPreAppStartSpansRequest{
+			ObservableServiceId: serviceID,
+			PageSize:            200,
+		}
+		if cur != "" {
+			req.PaginationCursor = &cur
+		}
+
+		resp, err := client.GetPreAppStartSpans(ctx, req, auth)
+		if err != nil {
+			return nil, fmt.Errorf("get pre-app-start spans: %w", err)
+		}
+		all = append(all, resp.Spans...)
+		if next := resp.GetNextCursor(); next != "" {
+			cur = next
+			continue
+		}
+		break
+	}
+	return all, nil
+}
+
+// FetchLocalPreAppStartSpans fetches pre-app-start spans from local trace files
+func FetchLocalPreAppStartSpans(interactive bool) ([]*core.Span, error) {
+	var out []*core.Span
+	seen := map[string]struct{}{}
+
+	for _, dir := range utils.GetPossibleTraceDirs() {
+		matches, err := filepath.Glob(filepath.Join(dir, "*trace*.jsonl"))
+		if err != nil {
+			continue
+		}
+		for _, f := range matches {
+			spans, err := utils.ParseSpansFromFile(f, func(s *core.Span) bool { return s.IsPreAppStart })
+			if err != nil {
+				if interactive {
+					logging.LogToService(fmt.Sprintf("❌ Failed to parse spans from %s: %v", f, err))
+				}
+				continue
+			}
+			for _, s := range spans {
+				key := s.TraceId + "|" + s.SpanId
+				if _, ok := seen[key]; ok {
+					continue
+				}
+				seen[key] = struct{}{}
+				out = append(out, s)
+			}
+		}
+	}
+	return out, nil
+}
+
+// fetchAllSuiteSpans fetches all suite spans from cloud (used for single trace test runs)
+func fetchAllSuiteSpans(
+	ctx context.Context,
+	client *api.TuskClient,
+	auth api.AuthOptions,
+	serviceID string,
+) ([]*core.Span, error) {
+	var spans []*core.Span
+	cur := ""
+	for {
+		req := &backend.GetAllTraceTestsRequest{
+			ObservableServiceId: serviceID,
+			PageSize:            100,
+		}
+		if cur != "" {
+			req.PaginationCursor = &cur
+		}
+		resp, err := client.GetAllTraceTests(ctx, req, auth)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch trace tests from backend: %w", err)
+		}
+		for _, tt := range resp.TraceTests {
+			if len(tt.Spans) > 0 {
+				spans = append(spans, tt.Spans...)
+			}
+		}
+		if next := resp.GetNextCursor(); next != "" {
+			cur = next
+			continue
+		}
+		break
+	}
+	return spans, nil
+}
+
+// DedupeSpans deduplicates spans by (trace_id, span_id) while preserving order
+func DedupeSpans(spans []*core.Span) []*core.Span {
+	if len(spans) <= 1 {
+		return spans
+	}
+	seen := make(map[string]struct{}, len(spans))
+	out := make([]*core.Span, 0, len(spans))
+
+	for _, s := range spans {
+		if s == nil {
+			continue
+		}
+		if s.TraceId != "" && s.SpanId != "" {
+			key := s.TraceId + "|" + s.SpanId
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+		out = append(out, s)
+	}
+
+	slog.Debug("Deduplicated suite spans", "inCount", len(spans), "outCount", len(out))
+	return out
+}

--- a/internal/runner/suite_spans_test.go
+++ b/internal/runner/suite_spans_test.go
@@ -1,0 +1,461 @@
+package runner
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	core "github.com/Use-Tusk/tusk-drift-schemas/generated/go/core"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestDedupeSpans(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []*core.Span
+		expected int
+	}{
+		{
+			name:     "empty_list",
+			input:    []*core.Span{},
+			expected: 0,
+		},
+		{
+			name: "single_span",
+			input: []*core.Span{
+				{TraceId: "trace1", SpanId: "span1"},
+			},
+			expected: 1,
+		},
+		{
+			name: "no_duplicates",
+			input: []*core.Span{
+				{TraceId: "trace1", SpanId: "span1"},
+				{TraceId: "trace1", SpanId: "span2"},
+				{TraceId: "trace2", SpanId: "span1"},
+			},
+			expected: 3,
+		},
+		{
+			name: "with_duplicates",
+			input: []*core.Span{
+				{TraceId: "trace1", SpanId: "span1"},
+				{TraceId: "trace1", SpanId: "span1"}, // duplicate
+				{TraceId: "trace1", SpanId: "span2"},
+				{TraceId: "trace1", SpanId: "span1"}, // duplicate
+			},
+			expected: 2,
+		},
+		{
+			name: "preserves_order",
+			input: []*core.Span{
+				{TraceId: "trace1", SpanId: "span1", Name: "first"},
+				{TraceId: "trace2", SpanId: "span2", Name: "second"},
+				{TraceId: "trace1", SpanId: "span1", Name: "duplicate"}, // should be dropped
+				{TraceId: "trace3", SpanId: "span3", Name: "third"},
+			},
+			expected: 3,
+		},
+		{
+			name: "handles_nil_spans",
+			input: []*core.Span{
+				{TraceId: "trace1", SpanId: "span1"},
+				nil,
+				{TraceId: "trace2", SpanId: "span2"},
+				nil,
+			},
+			expected: 2,
+		},
+		{
+			name: "handles_empty_ids",
+			input: []*core.Span{
+				{TraceId: "", SpanId: ""},
+				{TraceId: "trace1", SpanId: "span1"},
+				{TraceId: "", SpanId: ""},
+			},
+			expected: 3, // Empty IDs are kept but don't dedupe
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DedupeSpans(tt.input)
+			assert.Len(t, result, tt.expected)
+
+			// Verify no nil spans in output
+			for _, span := range result {
+				assert.NotNil(t, span)
+			}
+
+			// For preserves_order test, verify the order
+			if tt.name == "preserves_order" {
+				require.Len(t, result, 3)
+				assert.Equal(t, "first", result[0].Name)
+				assert.Equal(t, "second", result[1].Name)
+				assert.Equal(t, "third", result[2].Name)
+			}
+		})
+	}
+}
+
+func TestBuildSuiteSpansForRun_LocalMode(t *testing.T) {
+	t.Parallel()
+
+	// Create test spans
+	span1 := &core.Span{
+		TraceId:       "trace1",
+		SpanId:        "span1",
+		Name:          "operation1",
+		IsPreAppStart: false,
+	}
+	span2 := &core.Span{
+		TraceId:       "trace1",
+		SpanId:        "span2",
+		Name:          "operation2",
+		IsPreAppStart: true,
+	}
+	span3 := &core.Span{
+		TraceId:       "trace2",
+		SpanId:        "span3",
+		Name:          "operation3",
+		IsPreAppStart: false,
+	}
+
+	tests := []struct {
+		name                string
+		opts                SuiteSpanOptions
+		currentTests        []Test
+		expectedMinSpans    int // minimum expected (local pre-app-start might add more)
+		expectedPreAppCount int
+		expectedTraceCount  int
+	}{
+		{
+			name: "uses_current_tests_spans",
+			opts: SuiteSpanOptions{
+				IsCloudMode: false,
+				Interactive: false,
+			},
+			currentTests: []Test{
+				{TraceID: "trace1", Spans: []*core.Span{span1, span2}},
+				{TraceID: "trace2", Spans: []*core.Span{span3}},
+			},
+			expectedMinSpans:    3,
+			expectedPreAppCount: 1, // span2 is pre-app-start
+			expectedTraceCount:  2,
+		},
+		{
+			name: "prefers_all_tests_over_current",
+			opts: SuiteSpanOptions{
+				IsCloudMode: false,
+				Interactive: false,
+				AllTests: []Test{
+					{TraceID: "trace1", Spans: []*core.Span{span1, span2}},
+					{TraceID: "trace2", Spans: []*core.Span{span3}},
+				},
+			},
+			currentTests: []Test{
+				{TraceID: "trace1", Spans: []*core.Span{span1}}, // Only one span
+			},
+			expectedMinSpans:    3, // Should use AllTests, not currentTests
+			expectedPreAppCount: 1,
+			expectedTraceCount:  2,
+		},
+		{
+			name: "handles_empty_tests",
+			opts: SuiteSpanOptions{
+				IsCloudMode: false,
+				Interactive: false,
+			},
+			currentTests:        []Test{},
+			expectedMinSpans:    0,
+			expectedPreAppCount: 0,
+			expectedTraceCount:  0,
+		},
+		{
+			name: "deduplicates_spans",
+			opts: SuiteSpanOptions{
+				IsCloudMode: false,
+				Interactive: false,
+			},
+			currentTests: []Test{
+				{TraceID: "trace1", Spans: []*core.Span{span1, span2}},
+				{TraceID: "trace1", Spans: []*core.Span{span1, span2}}, // Duplicates
+			},
+			expectedMinSpans:    2, // Should dedupe
+			expectedPreAppCount: 1,
+			expectedTraceCount:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spans, _, traceCount, err := BuildSuiteSpansForRun(
+				context.Background(),
+				tt.opts,
+				tt.currentTests,
+			)
+
+			require.NoError(t, err)
+			assert.GreaterOrEqual(t, len(spans), tt.expectedMinSpans)
+
+			// Count pre-app-start spans in result
+			actualPreAppCount := 0
+			for _, s := range spans {
+				if s.IsPreAppStart {
+					actualPreAppCount++
+				}
+			}
+			assert.GreaterOrEqual(t, actualPreAppCount, tt.expectedPreAppCount)
+
+			// Note: traceCount might be higher if local pre-app-start spans are found
+			if tt.expectedTraceCount > 0 {
+				assert.GreaterOrEqual(t, traceCount, tt.expectedTraceCount)
+			}
+		})
+	}
+}
+
+func TestBuildSuiteSpansForRun_PreAppStartSpans(t *testing.T) {
+	t.Parallel()
+
+	// Create a mix of regular and pre-app-start spans
+	regularSpan := &core.Span{
+		TraceId:       "trace1",
+		SpanId:        "span1",
+		Name:          "regular",
+		IsPreAppStart: false,
+	}
+	preAppSpan1 := &core.Span{
+		TraceId:       "trace1",
+		SpanId:        "span2",
+		Name:          "preapp1",
+		IsPreAppStart: true,
+		Timestamp:     timestamppb.New(time.Now().Add(-1 * time.Hour)),
+	}
+	preAppSpan2 := &core.Span{
+		TraceId:       "trace2",
+		SpanId:        "span3",
+		Name:          "preapp2",
+		IsPreAppStart: true,
+		Timestamp:     timestamppb.New(time.Now().Add(-2 * time.Hour)),
+	}
+
+	tests := []struct {
+		name         string
+		currentTests []Test
+		wantMinSpans int
+		wantPreApp   bool
+	}{
+		{
+			name: "includes_pre_app_start_spans",
+			currentTests: []Test{
+				{
+					TraceID: "trace1",
+					Spans:   []*core.Span{regularSpan, preAppSpan1, preAppSpan2},
+				},
+			},
+			wantMinSpans: 3,
+			wantPreApp:   true,
+		},
+		{
+			name: "no_pre_app_start_spans",
+			currentTests: []Test{
+				{
+					TraceID: "trace1",
+					Spans:   []*core.Span{regularSpan},
+				},
+			},
+			wantMinSpans: 1,
+			wantPreApp:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spans, preAppCount, _, err := BuildSuiteSpansForRun(
+				context.Background(),
+				SuiteSpanOptions{
+					IsCloudMode: false,
+					Interactive: false,
+				},
+				tt.currentTests,
+			)
+
+			require.NoError(t, err)
+			assert.GreaterOrEqual(t, len(spans), tt.wantMinSpans)
+
+			if tt.wantPreApp {
+				assert.Greater(t, preAppCount, 0, "expected pre-app-start spans")
+
+				// Verify our test pre-app-start spans are in the result
+				foundPreApp1 := false
+				foundPreApp2 := false
+				for _, s := range spans {
+					if s.SpanId == "span2" && s.Name == "preapp1" {
+						foundPreApp1 = true
+					}
+					if s.SpanId == "span3" && s.Name == "preapp2" {
+						foundPreApp2 = true
+					}
+				}
+				assert.True(t, foundPreApp1, "expected to find preapp1 span")
+				assert.True(t, foundPreApp2, "expected to find preapp2 span")
+			}
+		})
+	}
+}
+
+func TestBuildSuiteSpansForRun_UniqueTraceCount(t *testing.T) {
+	t.Parallel()
+
+	span1 := &core.Span{TraceId: "trace1", SpanId: "span1"}
+	span2 := &core.Span{TraceId: "trace1", SpanId: "span2"}
+	span3 := &core.Span{TraceId: "trace2", SpanId: "span3"}
+	span4 := &core.Span{TraceId: "trace3", SpanId: "span4"}
+
+	tests := []struct {
+		name               string
+		currentTests       []Test
+		expectedTraceCount int
+	}{
+		{
+			name: "counts_unique_traces",
+			currentTests: []Test{
+				{TraceID: "trace1", Spans: []*core.Span{span1, span2}},
+				{TraceID: "trace2", Spans: []*core.Span{span3}},
+				{TraceID: "trace3", Spans: []*core.Span{span4}},
+			},
+			expectedTraceCount: 3,
+		},
+		{
+			name: "handles_duplicate_traces",
+			currentTests: []Test{
+				{TraceID: "trace1", Spans: []*core.Span{span1}},
+				{TraceID: "trace1", Spans: []*core.Span{span2}},
+			},
+			expectedTraceCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, traceCount, err := BuildSuiteSpansForRun(
+				context.Background(),
+				SuiteSpanOptions{
+					IsCloudMode: false,
+					Interactive: false,
+				},
+				tt.currentTests,
+			)
+
+			require.NoError(t, err)
+			// Note: might be higher due to local pre-app-start spans from other traces
+			assert.GreaterOrEqual(t, traceCount, tt.expectedTraceCount)
+		})
+	}
+}
+
+func TestPrepareAndSetSuiteSpans(t *testing.T) {
+	t.Parallel()
+
+	span1 := &core.Span{
+		TraceId: "trace1",
+		SpanId:  "span1",
+		Name:    "operation1",
+	}
+
+	tests := []struct {
+		name         string
+		opts         SuiteSpanOptions
+		currentTests []Test
+		wantError    bool
+		wantSpans    bool // whether we expect spans to be set (could be from local files too)
+	}{
+		{
+			name: "success_with_tests",
+			opts: SuiteSpanOptions{
+				IsCloudMode: false,
+				Interactive: false,
+			},
+			currentTests: []Test{
+				{TraceID: "trace1", Spans: []*core.Span{span1}},
+			},
+			wantError: false,
+			wantSpans: true,
+		},
+		{
+			name: "success_with_no_tests",
+			opts: SuiteSpanOptions{
+				IsCloudMode: false,
+				Interactive: false,
+			},
+			currentTests: []Test{},
+			wantError:    false,
+			wantSpans:    false, // May have spans from local files, so we don't assert
+		},
+		{
+			name: "success_interactive_mode",
+			opts: SuiteSpanOptions{
+				IsCloudMode: false,
+				Interactive: true, // Should log but not fail
+			},
+			currentTests: []Test{
+				{TraceID: "trace1", Spans: []*core.Span{span1}},
+			},
+			wantError: false,
+			wantSpans: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			executor := NewExecutor()
+
+			err := PrepareAndSetSuiteSpans(
+				context.Background(),
+				executor,
+				tt.opts,
+				tt.currentTests,
+			)
+
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				// Verify SetSuiteSpans was called (suiteSpans should be initialized)
+				// Note: it might be an empty slice, but should not be nil after SetSuiteSpans is called
+				if tt.wantSpans {
+					assert.NotNil(t, executor.suiteSpans)
+					assert.Greater(t, len(executor.suiteSpans), 0, "expected at least one span")
+				}
+				// For empty tests, we just verify no error - spans might come from local files
+			}
+		})
+	}
+}
+
+func TestDedupeSpans_PreservesFirstOccurrence(t *testing.T) {
+	t.Parallel()
+
+	// Create spans with same IDs but different data
+	span1 := &core.Span{
+		TraceId: "trace1",
+		SpanId:  "span1",
+		Name:    "first_occurrence",
+	}
+	span2 := &core.Span{
+		TraceId: "trace1",
+		SpanId:  "span1",
+		Name:    "second_occurrence",
+	}
+
+	input := []*core.Span{span1, span2}
+	result := DedupeSpans(input)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "first_occurrence", result[0].Name, "should preserve first occurrence")
+}


### PR DESCRIPTION
### Issue

When running tests from `tusk list` view, pre-app-start spans were not being loaded into the mock server, causing pre-app-start calls (e.g., DB queries) to fail.

### Changes

1. **Fixed list view execution**: Tests run from `tusk list` now properly load pre-app-start spans before starting the service
   - Local mode: Scans all local trace files for pre-app-start spans
   - Cloud mode: Fetches pre-app-start spans from backend
   - Includes spans from all loaded tests for cross-trace matching

2. **Refactored suite span logic**: Extracted ~410 lines of duplicate code into `internal/runner/suite_spans.go`
   - New `SuiteSpanOptions` struct for type-safe configuration
   - Shared functions across `list` and `run` commands: `BuildSuiteSpansForRun`, `PrepareAndSetSuiteSpans`, `FetchPreAppStartSpansFromCloud`, `FetchLocalPreAppStartSpans`, `DedupeSpans`
   - Consistent behavior across `run` and `list` commands

4. **Added `--enable-service-logs` flag to `list` command**: Enables service log capture when running tests from list view when `--enable-service-logs` or `--debug` flag is included.

5. **Improved list view timestamp information**: Changed "Timestamp" to "Recorded At" for clarity, timestamp now shows local timezone.

### Testing

- Run `tusk list` and execute a test that requires database access during startup
- Verify pre-app-start mocks are loaded and matched correctly
- Confirm both local and cloud modes work as expected