### PR TITLE
feat: improve TUI for displaying deviations + CTA

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -380,6 +380,7 @@ func runTests(cmd *cobra.Command, args []string) error {
 		_, err := tui.RunTestsInteractiveWithOpts(nil, executor, &tui.InteractiveOpts{
 			InitialServiceLogs:    initialLogs,
 			StartAfterTestsLoaded: true,
+			IsCloudMode:           cloud,
 			LoadTests: makeLoadTestsFunc(
 				executor,
 				client,

--- a/internal/tui/components/log_panel.go
+++ b/internal/tui/components/log_panel.go
@@ -195,7 +195,7 @@ func (lp *LogPanelComponent) IsFocused() bool {
 func (lp *LogPanelComponent) updateViewport() {
 	var content string
 
-	wrapWidth := lp.viewport.Width - 2 // Only subtract left + right padding (1 + 1)
+	wrapWidth := lp.viewport.Width - 4 // Subtract borders (2) and padding (2)
 	if wrapWidth <= 0 {
 		wrapWidth = 70 // Conservative fallback
 	}
@@ -205,8 +205,11 @@ func (lp *LogPanelComponent) updateViewport() {
 		var wrappedLines []string
 
 		for _, line := range lp.serviceLogs {
-			wrapped := utils.WrapLine(line, wrapWidth)
-			wrappedLines = append(wrappedLines, wrapped...)
+			subLines := strings.SplitSeq(line, "\n")
+			for subLine := range subLines {
+				wrapped := utils.WrapLine(subLine, wrapWidth)
+				wrappedLines = append(wrappedLines, wrapped...)
+			}
 		}
 		content = strings.Join(wrappedLines, "\n")
 	} else {
@@ -214,8 +217,11 @@ func (lp *LogPanelComponent) updateViewport() {
 			var wrappedLines []string
 
 			for _, line := range logs {
-				wrapped := utils.WrapLine(line, wrapWidth)
-				wrappedLines = append(wrappedLines, wrapped...)
+				subLines := strings.SplitSeq(line, "\n")
+				for subLine := range subLines {
+					wrapped := utils.WrapLine(subLine, wrapWidth)
+					wrappedLines = append(wrappedLines, wrapped...)
+				}
 			}
 			content = strings.Join(wrappedLines, "\n")
 		} else {
@@ -223,6 +229,6 @@ func (lp *LogPanelComponent) updateViewport() {
 		}
 	}
 
-	lp.viewport.SetContent(content)
+	lp.viewport.SetContent(utils.StripNoWrapMarker(content))
 	lp.viewport.GotoBottom()
 }

--- a/internal/tui/components/test_execution_header.go
+++ b/internal/tui/components/test_execution_header.go
@@ -91,7 +91,7 @@ func (h *TestExecutionHeaderComponent) View(width int) string {
 			"", // Empty line for spacing
 		)
 	} else {
-		statsText := fmt.Sprintf("%d/%d completed | 🏃 %d running | ✅ %d passed | ❌ %d failed",
+		statsText := fmt.Sprintf("%d/%d completed | 🏃 %d running | ✅ %d passed | 🟠 %d deviations",
 			h.completed, h.testCount, h.running, h.passed, h.failed,
 		)
 		statsWidth := lipgloss.Width(statsText) + 1 // Space between bar and stats
@@ -129,4 +129,14 @@ func (h *TestExecutionHeaderComponent) UpdateStats(completed, passed, failed, ru
 
 func (h *TestExecutionHeaderComponent) SetCompleted() {
 	h.state = "completed"
+}
+
+func (h *TestExecutionHeaderComponent) SetInitialProgress() tea.Cmd {
+	if h.testCount > 0 {
+		percent := 0.5 / float64(h.testCount)
+		return h.progress.SetPercent(percent)
+	}
+
+	// Fallback to 0% if we don't know test count yet
+	return h.progress.SetPercent(0.0)
 }

--- a/internal/tui/components/test_table.go
+++ b/internal/tui/components/test_table.go
@@ -29,7 +29,7 @@ func NewTestTableComponent(tests []runner.Test) *TestTableComponent {
 	columns := []table.Column{
 		{Title: "#", Width: 4},
 		{Title: "Test", Width: 35},
-		{Title: "Status", Width: 10},
+		{Title: "Status", Width: 17},
 		{Title: "Duration", Width: 8},
 	}
 
@@ -152,9 +152,9 @@ func (tt *TestTableComponent) buildRows() {
 			case err != nil:
 				status = "❌ Error"
 			case result.Passed:
-				status = "✅ Passed"
+				status = "✅ No deviation"
 			default:
-				status = "❌ Failed"
+				status = "🟠 Deviation"
 			}
 			duration = fmt.Sprintf("%dms", result.Duration)
 		}

--- a/internal/tui/list.go
+++ b/internal/tui/list.go
@@ -132,6 +132,7 @@ func (m *listModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					for _, test := range m.tests {
 						if test.TraceID == traceID {
 							opts := &InteractiveOpts{
+								IsCloudMode:              m.suiteOpts.IsCloudMode,
 								OnBeforeEnvironmentStart: m.createSuiteSpanPreparation(),
 							}
 							executor := newTestExecutorModel([]runner.Test{test}, m.executor, opts)

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -1,41 +1,174 @@
 package utils
 
-import "strings"
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
 
-// WrapText wraps a single line of text to the specified width, trying to break at word boundaries
+	"github.com/pmezard/go-difflib/difflib"
+)
+
+const NoWrapMarker = "\x00NOWRAP\x00"
+
+// MarkNonWrappable adds an invisible marker to indicate text should not be wrapped
+func MarkNonWrappable(text string) string {
+	return NoWrapMarker + text
+}
+
+// StripNoWrapMarker removes the non-wrappable marker from text before display
+func StripNoWrapMarker(text string) string {
+	return strings.ReplaceAll(text, NoWrapMarker, "")
+}
+
+// ANSI color code regex pattern
+var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+// stripANSI removes ANSI escape sequences from a string
+func stripANSI(s string) string {
+	return ansiRegex.ReplaceAllString(s, "")
+}
+
+// visibleLen returns the visible length of a string (excluding ANSI codes)
+func visibleLen(s string) int {
+	return len(stripANSI(s))
+}
+
+// WrapLine wraps a single line of text to the specified width, trying to break at word boundaries
+// This function is ANSI-aware and preserves color codes
+// It avoids wrapping lines that appear to be formatted output (like diffs)
 func WrapLine(text string, maxWidth int) []string {
 	if maxWidth <= 0 {
 		maxWidth = 80
 	}
 
-	if len(text) <= maxWidth {
+	// Don't wrap lines marked as non-wrappable (used for diffs and structured output)
+	// Strip the marker immediately after checking
+	if strings.Contains(text, NoWrapMarker) {
+		return []string{strings.ReplaceAll(text, NoWrapMarker, "")}
+	}
+
+	// Check visible length, not actual length (excluding ANSI codes)
+	if visibleLen(text) <= maxWidth {
 		return []string{text}
 	}
 
+	// Preserve leading whitespace
+	leadingSpaces := len(text) - len(strings.TrimLeft(text, " "))
+	leadingWhitespace := text[:leadingSpaces]
+	trimmedText := text[leadingSpaces:]
+
 	var lines []string
-	for len(text) > maxWidth {
-		breakPoint := maxWidth
-		// Try to break at a space to avoid breaking words
-		for i := maxWidth - 1; i >= maxWidth/2; i-- {
-			if text[i] == ' ' {
-				breakPoint = i
-				break
+	currentLine := leadingWhitespace
+	currentVisibleLen := leadingSpaces
+
+	// Split by spaces to wrap at word boundaries
+	words := strings.Fields(trimmedText)
+
+	// If there are no spaces (single long word) and it's too long, split it
+	if len(words) == 1 && visibleLen(words[0]) > maxWidth-leadingSpaces {
+		chunks := splitLongWord(words[0], maxWidth-leadingSpaces)
+		for _, chunk := range chunks {
+			lines = append(lines, leadingWhitespace+chunk)
+		}
+		return lines
+	}
+
+	for i, word := range words {
+		wordVisibleLen := visibleLen(word)
+		spaceLen := 1 // Space between words
+
+		// If this individual word is too long to fit even on its own line, split it
+		if wordVisibleLen > maxWidth-leadingSpaces {
+			// Save current line if it has content
+			if currentLine != leadingWhitespace {
+				lines = append(lines, currentLine)
 			}
+
+			// Split the long word
+			chunks := splitLongWord(word, maxWidth-leadingSpaces)
+			for j, chunk := range chunks {
+				if j < len(chunks)-1 {
+					// All chunks except the last get their own line
+					lines = append(lines, leadingWhitespace+chunk)
+				} else {
+					// Last chunk starts the next line
+					currentLine = leadingWhitespace + chunk
+					currentVisibleLen = leadingSpaces + visibleLen(chunk)
+				}
+			}
+			continue
 		}
 
-		lines = append(lines, text[:breakPoint])
-		text = text[breakPoint:]
-		// Remove leading space from the next line
-		if len(text) > 0 && text[0] == ' ' {
-			text = text[1:]
+		switch {
+		case i == 0:
+			// First word, no leading space
+			currentLine += word
+			currentVisibleLen += wordVisibleLen
+		case currentVisibleLen+spaceLen+wordVisibleLen <= maxWidth:
+			// Word fits on current line
+			currentLine += " " + word
+			currentVisibleLen += spaceLen + wordVisibleLen
+		default:
+			// Word doesn't fit, start new line
+			lines = append(lines, currentLine)
+			currentLine = leadingWhitespace + word
+			currentVisibleLen = leadingSpaces + wordVisibleLen
 		}
 	}
 
-	if len(text) > 0 {
-		lines = append(lines, text)
+	// Add last line
+	if currentLine != "" && currentLine != leadingWhitespace {
+		lines = append(lines, currentLine)
+	}
+
+	if len(lines) == 0 {
+		return []string{text}
 	}
 
 	return lines
+}
+
+// splitLongWord splits a word that's longer than maxWidth into chunks
+// This is ANSI-aware and tries to preserve ANSI codes properly
+func splitLongWord(word string, maxWidth int) []string {
+	if maxWidth <= 0 {
+		maxWidth = 80
+	}
+
+	// For simplicity with ANSI codes, we'll strip them, split, then try to preserve
+	// This is a basic implementation that works for most cases
+	stripped := stripANSI(word)
+	if len(stripped) <= maxWidth {
+		return []string{word}
+	}
+
+	// If there are no ANSI codes, simple split
+	if word == stripped {
+		var chunks []string
+		for len(stripped) > 0 {
+			if len(stripped) <= maxWidth {
+				chunks = append(chunks, stripped)
+				break
+			}
+			chunks = append(chunks, stripped[:maxWidth])
+			stripped = stripped[maxWidth:]
+		}
+		return chunks
+	}
+
+	// TODO: Handle ANSI codes more carefully if needed
+	// For now, just do a basic split ignoring ANSI codes
+	var chunks []string
+	for len(stripped) > 0 {
+		if len(stripped) <= maxWidth {
+			chunks = append(chunks, stripped)
+			break
+		}
+		chunks = append(chunks, stripped[:maxWidth])
+		stripped = stripped[maxWidth:]
+	}
+	return chunks
 }
 
 // WrapLogs wraps multiple lines of log content to fit within the specified width
@@ -53,4 +186,114 @@ func WrapText(content string, maxWidth int) string {
 	}
 
 	return strings.Join(wrappedLines, "\n")
+}
+
+// FormatJSONForDiff formats a JSON value with proper indentation for diff display
+func FormatJSONForDiff(v any) string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	// If it's already a string, try to parse it as JSON first
+	if str, ok := v.(string); ok {
+		var parsed any
+		if err := json.Unmarshal([]byte(str), &parsed); err == nil {
+			v = parsed
+		} else {
+			// Not valid JSON, return as is
+			return str
+		}
+	}
+
+	// Pretty print the JSON
+	b, err := json.MarshalIndent(v, "      ", "  ")
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+
+	return string(b)
+}
+
+// FormatJSONDiff creates a git-style unified diff between two JSON values
+func FormatJSONDiff(expected, actual any) string {
+	expectedJSON := formatJSONForDiff(expected)
+	actualJSON := formatJSONForDiff(actual)
+
+	if expectedJSON == actualJSON {
+		return "No differences found"
+	}
+
+	// Generate unified diff
+	diff := difflib.UnifiedDiff{
+		A:        difflib.SplitLines(expectedJSON),
+		B:        difflib.SplitLines(actualJSON),
+		FromFile: "Expected",
+		ToFile:   "Actual",
+		Context:  5,
+	}
+
+	result, err := difflib.GetUnifiedDiffString(diff)
+	if err != nil {
+		// Fallback to simple side-by-side if diff fails
+		return fmt.Sprintf("Expected:\n%s\n\nActual:\n%s", expectedJSON, actualJSON)
+	}
+
+	red := "\033[31m"
+	green := "\033[32m"
+	cyan := "\033[36m"
+	gray := "\033[38;5;250m"
+	reset := "\033[0m"
+
+	lines := strings.Split(result, "\n")
+	var indentedLines []string
+
+	topDelimiter := "  " + gray + "╭─" + strings.Repeat("─", 22) + " Diff " + strings.Repeat("─", 22) + "" + reset
+	bottomDelimiter := "  " + gray + "╰─" + strings.Repeat("─", 50) + reset
+
+	indentedLines = append(indentedLines, MarkNonWrappable(topDelimiter))
+
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++"):
+			indentedLines = append(indentedLines, MarkNonWrappable("    "+cyan+line+reset))
+		case strings.HasPrefix(line, "-"):
+			indentedLines = append(indentedLines, MarkNonWrappable("    "+red+line+reset))
+		case strings.HasPrefix(line, "+"):
+			indentedLines = append(indentedLines, MarkNonWrappable("    "+green+line+reset))
+		case strings.HasPrefix(line, "@@"):
+			indentedLines = append(indentedLines, MarkNonWrappable("    "+cyan+line+reset))
+		default:
+			indentedLines = append(indentedLines, MarkNonWrappable("    "+gray+line+reset))
+		}
+	}
+
+	indentedLines = append(indentedLines, MarkNonWrappable(bottomDelimiter))
+	return strings.Join(indentedLines, "\n")
+}
+
+// formatJSONForDiff is a helper that formats JSON without the extra indentation prefix
+func formatJSONForDiff(v any) string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	if str, ok := v.(string); ok {
+		var parsed any
+		if err := json.Unmarshal([]byte(str), &parsed); err == nil {
+			v = parsed
+		} else {
+			// Not valid JSON, return as is
+			return str
+		}
+	}
+
+	b, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+
+	return string(b)
 }


### PR DESCRIPTION
### Changes

**TUI Improvements**
- Changed "passed/failed" to "deviation / no deviation" throughout the TUI to be more consistent with cloud UI.
- Use 🟠 for deviations instead of ❌ as a softer alert, since they are yet to be classified as intended or unintended
- Response body deviations now show git-style unified diffs with syntax highlighting instead of raw JSON dumps
- Enhanced log panel wrapping to handle ANSI color codes correctly and respect structured output like diffs
  - Added `NoWrapMarker` system to prevent wrapping of formatted content (diffs, boxes)
  - Fixed viewport width calculations to account for borders and padding
- Initialize progress bar with minimal progress during environment setup for better visual feedback

**Cloud Mode Integration**
- Show CTA about Tusk Drift Cloud's root cause analysis feature when deviations are detected in local mode, thread `IsCloudMode` through TUI components to conditionally show/hide this