### PR TITLE
feat: improve onboarding wizard for docker setups

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -296,7 +296,6 @@ For authentication in cloud mode, either use:
       <th>Key</th>
       <th>Type</th>
       <th>Default</th>
-      <th>Env override</th>
       <th>Description</th>
     </tr>
   </thead>
@@ -305,8 +304,19 @@ For authentication in cloud mode, either use:
       <td><code>recording.sampling_rate</code></td>
       <td>number</td>
       <td>0.1</td>
-      <td><code>TUSK_RECORDING_SAMPLING_RATE</code></td>
       <td>Target sampling fraction when recording traces.</td>
+    </tr>
+    <tr>
+      <td><code>recording.export_spans</code></td>
+      <td>boolean</td>
+      <td><code>false</code></td>
+      <td>Whether to export spans to the Tusk Drift Cloud. If false, spans are saved locally in <code>traces.dir</code></td>
+    </tr>
+    <tr>
+      <td><code>recording.export_env_var_recording</code></td>
+      <td>boolean</td>
+      <td><code>false</code></td>
+      <td>Whether to record and replay environment variables. Recommended for accurate replay behavior if your service's logic depends on environment variables.</td>
     </tr>
   </tbody>
 </table>

--- a/internal/tui/onboard/config.go
+++ b/internal/tui/onboard/config.go
@@ -57,7 +57,9 @@ type TestExecution struct {
 }
 
 type Recording struct {
-	SamplingRate float64 `yaml:"sampling_rate"`
+	SamplingRate          float64 `yaml:"sampling_rate"`
+	ExportSpans           bool    `yaml:"export_spans"`
+	EnableEnvVarRecording bool    `yaml:"enable_env_var_recording"`
 }
 
 type Traces struct {
@@ -106,7 +108,9 @@ func (m *Model) getCurrentConfig() Config {
 			Timeout: "30s",
 		},
 		Recording: Recording{
-			SamplingRate: samplingRate,
+			SamplingRate:          samplingRate,
+			ExportSpans:           false,
+			EnableEnvVarRecording: true,
 		},
 	}
 

--- a/internal/tui/onboard/docker.go
+++ b/internal/tui/onboard/docker.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 func hasDockerfile() bool {
@@ -31,8 +33,8 @@ func inferDockerPort() string {
 	dockerfiles := []string{"Dockerfile", "dockerfile"}
 	for _, df := range dockerfiles {
 		if data, err := os.ReadFile(df); err == nil { //nolint:gosec
-			lines := strings.Split(string(data), "\n")
-			for _, line := range lines {
+			lines := strings.SplitSeq(string(data), "\n")
+			for line := range lines {
 				if strings.HasPrefix(strings.TrimSpace(line), "EXPOSE") {
 					parts := strings.Fields(line)
 					if len(parts) >= 2 {
@@ -43,6 +45,116 @@ func inferDockerPort() string {
 		}
 	}
 	return "3000"
+}
+
+func inferDockerComposePort() string {
+	composePath := getDockerComposeFilePath()
+	if composePath == "" {
+		return ""
+	}
+
+	data, err := os.ReadFile(composePath) //nolint:gosec
+	if err != nil {
+		return ""
+	}
+
+	var root yaml.Node // Preserves order
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return ""
+	}
+
+	if len(root.Content) == 0 {
+		return ""
+	}
+
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return ""
+	}
+
+	var servicesNode *yaml.Node
+	for i := 0; i < len(doc.Content); i += 2 {
+		keyNode := doc.Content[i]
+		if keyNode.Value == "services" && i+1 < len(doc.Content) {
+			servicesNode = doc.Content[i+1]
+			break
+		}
+	}
+
+	if servicesNode == nil || servicesNode.Kind != yaml.MappingNode || len(servicesNode.Content) < 2 {
+		return ""
+	}
+
+	// Get the first service (index 1 is the value node for the first service)
+	firstServiceNode := servicesNode.Content[1]
+	if firstServiceNode.Kind != yaml.MappingNode {
+		return ""
+	}
+
+	var portsNode *yaml.Node
+	for i := 0; i < len(firstServiceNode.Content); i += 2 {
+		keyNode := firstServiceNode.Content[i]
+		if keyNode.Value == "ports" && i+1 < len(firstServiceNode.Content) {
+			portsNode = firstServiceNode.Content[i+1]
+			break
+		}
+	}
+
+	if portsNode == nil || portsNode.Kind != yaml.SequenceNode || len(portsNode.Content) == 0 {
+		return ""
+	}
+
+	firstPortNode := portsNode.Content[0]
+
+	// Handle string format: "8089:8080" or similar
+	if firstPortNode.Kind == yaml.ScalarNode {
+		return extractPublishedPort(firstPortNode.Value)
+	}
+
+	// Handle map format: {target: 8080, published: 8089}
+	if firstPortNode.Kind == yaml.MappingNode {
+		for i := 0; i < len(firstPortNode.Content); i += 2 {
+			keyNode := firstPortNode.Content[i]
+			if keyNode.Value == "published" && i+1 < len(firstPortNode.Content) {
+				valueNode := firstPortNode.Content[i+1]
+				return valueNode.Value
+			}
+		}
+	}
+
+	return ""
+}
+
+// extractPublishedPort extracts the published (host) port from a port string
+// Handles formats like:
+// - "8089:8080" -> "8089"
+// - "0.0.0.0:8089:8080" -> "8089"
+// - "8089" -> "8089"
+func extractPublishedPort(portStr string) string {
+	parts := strings.Split(portStr, ":")
+
+	if len(parts) == 1 {
+		// Just a single port number
+		return strings.TrimSpace(parts[0])
+	}
+
+	if len(parts) == 2 {
+		// Format: "published:target" or "ip:port"
+		// If first part is an IP (contains dots), return second part
+		// Otherwise return first part
+		first := strings.TrimSpace(parts[0])
+		if strings.Contains(first, ".") {
+			return strings.TrimSpace(parts[1])
+		}
+		return first
+	}
+
+	if len(parts) == 3 {
+		// Format: "ip:published:target"
+		return strings.TrimSpace(parts[1])
+	}
+
+	return ""
 }
 
 func inferDockerImageName() string {
@@ -80,5 +192,47 @@ func getDockerComposeFilePath() string {
 			return f
 		}
 	}
+	return ""
+}
+
+// getFirstDockerComposeServiceName returns the name of the first service in docker-compose.yml
+// This is typically the main application service
+func getFirstDockerComposeServiceName() string {
+	composePath := getDockerComposeFilePath()
+	if composePath == "" {
+		return ""
+	}
+
+	data, err := os.ReadFile(composePath) //nolint:gosec
+	if err != nil {
+		return ""
+	}
+
+	var root yaml.Node // Preserves order
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return ""
+	}
+
+	if len(root.Content) == 0 {
+		return ""
+	}
+
+	doc := root.Content[0]
+	if doc.Kind != yaml.MappingNode {
+		return ""
+	}
+
+	// Find the "services" key in the document, then get first service at index 0
+	for i := 0; i < len(doc.Content); i += 2 {
+		keyNode := doc.Content[i]
+		if keyNode.Value == "services" && i+1 < len(doc.Content) {
+			servicesNode := doc.Content[i+1]
+			if servicesNode.Kind == yaml.MappingNode && len(servicesNode.Content) >= 2 {
+				firstServiceName := servicesNode.Content[0].Value
+				return firstServiceName
+			}
+		}
+	}
+
 	return ""
 }

--- a/internal/tui/onboard/helpers.go
+++ b/internal/tui/onboard/helpers.go
@@ -35,7 +35,7 @@ func inputLabelForStep(s onboardStep) string {
 }
 
 func (m *Model) serviceNameDefault() string {
-	if m.DockerType == dockerTypeFile && strings.TrimSpace(m.DockerAppName) != "" {
+	if (m.DockerType == dockerTypeFile || m.DockerType == dockerTypeCompose) && strings.TrimSpace(m.DockerAppName) != "" {
 		return m.DockerAppName
 	}
 	return inferServiceNameFromDir()
@@ -45,6 +45,11 @@ func (m *Model) servicePortDefault() string {
 	if m.DockerType == dockerTypeFile {
 		if inferred := inferDockerPort(); inferred != "" && inferred != "3000" {
 			return fmt.Sprintf("%s (detected from Dockerfile)", inferred)
+		}
+	}
+	if m.DockerType == dockerTypeCompose {
+		if inferred := inferDockerComposePort(); inferred != "" && inferred != "3000" {
+			return fmt.Sprintf("%s (detected from Docker Compose)", inferred)
 		}
 	}
 	return "3000"

--- a/internal/tui/onboard/model.go
+++ b/internal/tui/onboard/model.go
@@ -47,8 +47,9 @@ type Model struct {
 	height  int
 
 	// Viewport for scrollable content (used in confirm step)
-	viewport      viewport.Model
-	viewportReady bool
+	viewport            viewport.Model
+	viewportReady       bool
+	lastViewportContent string // For preserving scroll
 
 	// State
 	ServiceName       string
@@ -60,10 +61,11 @@ type Model struct {
 	ReadinessInterval string
 	SamplingRate      string
 
-	UseDocker       bool
-	DockerType      dockerType
-	DockerImageName string
-	DockerAppName   string
+	UseDocker                bool
+	DockerType               dockerType
+	DockerImageName          string
+	DockerAppName            string
+	DockerComposeServiceName string // For docker compose override, may not be the same as ServiceName
 
 	SDKCompatible bool
 

--- a/internal/tui/onboard/steps.go
+++ b/internal/tui/onboard/steps.go
@@ -175,7 +175,7 @@ func (DockerTypeStep) Default(*Model) string  { return "" }
 func (DockerTypeStep) InputIndex() int        { return -1 }
 func (DockerTypeStep) Question(*Model) string { return "Are you using Docker Compose or Dockerfile?" }
 func (DockerTypeStep) Description(*Model) string {
-	return "Type 'c' for Docker Compose or 'd' for Dockerfile"
+	return "Press 'c' for Docker Compose or 'd' for Dockerfile"
 }
 func (DockerTypeStep) Help(*Model) string       { return "c: Docker Compose • d: Dockerfile • esc: quit" }
 func (DockerTypeStep) ShouldSkip(m *Model) bool { return !m.UseDocker }


### PR DESCRIPTION
- Better adapt input defaults to existing Dockerfile / Docker Compose configs. This also includes the Docker Compose override file (use the first service key instead of service name).
- Fix viewport issues for confirmation step
- Add defaults and configuration details for other recording-specific parameters (`recording.export_spans`, `recording.export_env_var_recording`)
