### PR TITLE
fix: improve port detection

### DIFF
--- a/internal/runner/service.go
+++ b/internal/runner/service.go
@@ -140,7 +140,7 @@ func (e *Executor) GetServiceLogPath() string {
 
 // checkProcessOnPort checks if any process is listening on the specified port
 // Returns true if a process is found, false otherwise
-// This uses a connection-based approach to check if the port.
+// This uses a connection-based approach to check if the port is already in use.
 func (e *Executor) checkProcessOnPort(port int) (bool, error) {
 	slog.Debug("Checking for existing processes on port", "port", port)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches port-in-use detection to a TCP connect approach and adds guidance to the readiness-timeout error.
> 
> - **Runner (`internal/runner/service.go`)**:
>   - **Port detection**: Replace bind-listen check with `net.DialTimeout("localhost:port", 500ms)`; logs updated to reflect connection-based check.
>   - **Readiness**: Error message now suggests increasing `service.readiness.timeout` in `.tusk/config.yaml` when timing out.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9dbab64dd108a1440964b703568da2d630c981b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->