### PR TITLE
fix: improve port running error message

### DIFF
--- a/internal/runner/service.go
+++ b/internal/runner/service.go
@@ -35,7 +35,7 @@ func (e *Executor) StartService() error {
 	if err != nil {
 		slog.Debug("Failed to check for existing processes on port", "port", cfg.Service.Port, "error", err)
 	} else if processExists {
-		return fmt.Errorf("port %d is already in use", cfg.Service.Port)
+		return fmt.Errorf("port %d is already in use, if your service is already running you should stop it first", cfg.Service.Port)
 	}
 
 	slog.Debug("Starting service", "command", cfg.Service.Start.Command)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Clarifies the port-in-use error message in `internal/runner/service.go` to advise stopping an already-running service.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01c12fc6f1e9c9c36cf84557088791c9df4268a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->