### PR TITLE
chore: bump schemas to v0.1.13 + update compatibility step copy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Use-Tusk/tusk-drift-cli
 go 1.25.0
 
 require (
-	github.com/Use-Tusk/tusk-drift-schemas v0.1.11
+	github.com/Use-Tusk/tusk-drift-schemas v0.1.13
 	github.com/agnivade/levenshtein v1.0.3
 	github.com/atotto/clipboard v0.1.4
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Use-Tusk/tusk-drift-schemas v0.1.11 h1:pmugIv0c8ZA4pEEtWii7OyttfoSEyzwTfMZp8u4rj2A=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.11/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
+github.com/Use-Tusk/tusk-drift-schemas v0.1.13 h1:OhtAbIpAKwJj5PGoW1ilr5WlbigJJdmSVlcJ+LUjBUs=
+github.com/Use-Tusk/tusk-drift-schemas v0.1.13/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
 github.com/agnivade/levenshtein v1.0.3 h1:M5ZnqLOoZR8ygVq0FfkXsNOKzMCk0xRiow0R5+5VkQ0=
 github.com/agnivade/levenshtein v1.0.3/go.mod h1:4SFRZbbXWLF4MU1T9Qg0pGgH3Pjs+t6ie5efyrwRJXs=
 github.com/alecthomas/assert/v2 v2.7.0 h1:QtqSACNS3tF7oasA8CU6A6sXZSBDqnm7RfpLl9bZqbE=

--- a/internal/tui/onboard/steps.go
+++ b/internal/tui/onboard/steps.go
@@ -61,6 +61,7 @@ func (SDKCompatibilityStep) Description(*Model) string {
 	return `Tusk Drift Node SDK currently supports:
   • HTTP/HTTPS: All versions (Node.js built-in)
   • PG: pg@8.x, pg-pool@2.x-3.x
+	• Firestore: @google-cloud/firestore@7.x
   • Postgres: postgres@3.x
   • MySQL: mysql2@3.x
   • IORedis: ioredis@4.x-5.x


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Bumps `tusk-drift-schemas` to v0.1.13 and updates onboarding copy to include Firestore as a supported package.
> 
> - **Dependencies**:
>   - Bump `github.com/Use-Tusk/tusk-drift-schemas` from `v0.1.11` to `v0.1.13` in `go.mod` (and `go.sum`).
> - **TUI Onboarding**:
>   - Update `SDKCompatibilityStep` description in `internal/tui/onboard/steps.go` to include support for `@google-cloud/firestore@7.x`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4178763526f02ce10cffe8cfe76c043294727ce7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->