### PR TITLE
ci: update release workflow to publish latest version manifest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,3 +55,35 @@ jobs:
     with:
       base64-subjects: "${{ needs.goreleaser.outputs.hashes }}"
       upload-assets: true
+
+  publish-version:
+    needs: [goreleaser]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Update latest version
+        run: |
+          echo "${{ github.ref_name }}" > gh-pages/latest.txt
+
+          cat > gh-pages/latest.json << EOF
+          {
+            "version": "${{ github.ref_name }}",
+            "published_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "url": "https://github.com/Use-Tusk/tusk-drift-cli/releases/tag/${{ github.ref_name }}"
+          }
+          EOF
+
+      - name: Commit and push to gh-pages
+        working-directory: gh-pages
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add latest.txt latest.json
+          git commit -m "Update latest version to ${{ github.ref_name }}" || echo "No changes to commit"
+          git push origin gh-pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,6 +134,7 @@ Releases are automated using [GoReleaser](https://goreleaser.com/) via GitHub Ac
    - Generate checksums
    - Create a GitHub release with changelog
    - Upload all artifacts
+   - Update the latest version manifest on [GitHub Pages](https://use-tusk.github.io/tusk-drift-cli/).
 
 #### Supported platforms
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Tusk Drift is an API test record/replay system that lets you run realistic tests
 
 ![GitHub Release](https://img.shields.io/github/v/release/Use-Tusk/tusk-drift-cli)
 [![Build and test](https://github.com/Use-Tusk/tusk-drift-cli/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/Use-Tusk/tusk-drift-cli/actions/workflows/main.yml)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11340/badge)](https://www.bestpractices.dev/projects/11340)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Use-Tusk/tusk-drift-cli)](https://goreportcard.com/report/github.com/Use-Tusk/tusk-drift-cli)
-[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 <br>
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![X URL](https://img.shields.io/twitter/url?url=https%3A%2F%2Fx.com%2Fusetusk&style=flat&logo=x&label=Tusk&color=BF40BF)](https://x.com/usetusk)
 [![Slack URL](https://img.shields.io/badge/slack-badge?style=flat&logo=slack&label=Tusk&color=BF40BF)](https://join.slack.com/t/tusk-community/shared_invite/zt-3fve1s7ie-NAAUn~UpHsf1m_2tdoGjsQ)
 
@@ -40,7 +41,11 @@ SDKs:
 **Linux/macOS:**
 
 ```bash
+# Install latest version
 curl -fsSL https://raw.githubusercontent.com/Use-Tusk/tusk-drift-cli/main/install.sh | sh
+
+# Install a specific version
+curl -fsSL https://raw.githubusercontent.com/Use-Tusk/tusk-drift-cli/main/install.sh | sh -s -- v1.2.3
 ```
 
 **Homebrew:**

--- a/install.sh
+++ b/install.sh
@@ -47,7 +47,13 @@ if [ -n "$REQUESTED_VERSION" ]; then
     *)  VERSION_TAG="v$REQUESTED_VERSION" ;;
   esac
 else
-  VERSION_TAG=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  # Try manifest first (fast, no rate limits)
+  VERSION_TAG=$(curl -s "https://use-tusk.github.io/tusk-drift-cli/latest.txt" 2>/dev/null || echo "")
+  
+  # Fallback to GitHub API if manifest fails
+  if [ -z "$VERSION_TAG" ]; then
+    VERSION_TAG=$(curl -s "https://api.github.com/repos/$REPO/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+  fi
 fi
 
 if [ -z "$VERSION_TAG" ]; then


### PR DESCRIPTION
During release, update a latest version manifest on GitHub Pages. This avoids `install.sh` having to query GitHub API for the latest release, which can easily hit rate limits for unauthenticated requests, and thus not ideal for CI workflows.

We still use the GitHub API query as a fallback.