### PR TITLE
fix: prevent exiting with error if there are deviations in CI mode

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -519,6 +519,11 @@ func runTests(cmd *cobra.Command, args []string) error {
 
 	if outputErr != nil {
 		cmd.SilenceUsage = true
+		// In CI mode, don't fail on test deviations - only fail on execution/upload errors
+		// As long as all tests ran and results were uploaded successfully, we want the CI workflow to pass.
+		if ci && cloud {
+			return nil
+		}
 		return outputErr
 	}
 


### PR DESCRIPTION
Don't exit with error code if running this in CI. As long as test execution and results upload are okay, the CI workflow should succeed.