### PR TITLE
feat: improve TUI for narrow terminal windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Interactive TUI (default when attached to a terminal):
 tusk run
 ```
 
+The TUI is best viewed in a window size of at least 150 x 40.
+
 Run headless mode with JSON output for a single test:
 
 ```bash

--- a/internal/tui/components/log_panel.go
+++ b/internal/tui/components/log_panel.go
@@ -59,13 +59,18 @@ func (lp *LogPanelComponent) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (lp *LogPanelComponent) View(width, height int) string {
+	lp.logMutex.Lock()
+	defer lp.logMutex.Unlock()
+
 	// Safety checks for dimensions
 	if width <= 0 {
-		width = 50 // Fallback width
+		width = 50
 	}
 	if height <= 0 {
-		height = 20 // Fallback height
+		height = 10
 	}
+
+	lp.updateViewport()
 
 	viewportWidth := width - 4   // Account for borders (2) and padding (2)
 	viewportHeight := height - 3 // Space for title and borders
@@ -92,7 +97,7 @@ func (lp *LogPanelComponent) View(width, height int) string {
 		BorderForeground(borderColor).
 		PaddingLeft(1).
 		PaddingRight(1).
-		Width(width)
+		MaxWidth(width)
 
 	// Determine title and content
 	title := "Service Logs"

--- a/internal/tui/components/terminal_size_warning.go
+++ b/internal/tui/components/terminal_size_warning.go
@@ -1,0 +1,117 @@
+package components
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Use-Tusk/tusk-drift-cli/internal/tui/styles"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	// Slightly wider than the minimum width for
+	// horizontal layout for test execution view
+	TestViewMinRecommendedWidth  = 150
+	TestViewMinRecommendedHeight = 40
+
+	// Below this, show warning overlay
+	TestViewAbsoluteMinWidth  = 60
+	TestViewAbsoluteMinHeight = 25
+)
+
+const (
+	ListViewMinRecommendedWidth  = 140
+	ListViewMinRecommendedHeight = 20
+
+	// Below this, show warning overlay
+	ListViewAbsoluteMinWidth  = 55
+	ListViewAbsoluteMinHeight = 15
+)
+
+// TerminalSizeWarning handles the terminal size warning overlay
+type TerminalSizeWarning struct {
+	dismissed         bool
+	minWidth          int
+	minHeight         int
+	recommendedWidth  int
+	recommendedHeight int
+}
+
+func NewTerminalSizeWarning(minWidth, minHeight, recommendedWidth, recommendedHeight int) *TerminalSizeWarning {
+	return &TerminalSizeWarning{
+		dismissed:         false,
+		minWidth:          minWidth,
+		minHeight:         minHeight,
+		recommendedWidth:  recommendedWidth,
+		recommendedHeight: recommendedHeight,
+	}
+}
+
+// NewTestExecutorSizeWarning creates a warning for test view
+func NewTestViewSizeWarning() *TerminalSizeWarning {
+	return NewTerminalSizeWarning(TestViewAbsoluteMinWidth, TestViewAbsoluteMinHeight, TestViewMinRecommendedWidth, TestViewMinRecommendedHeight)
+}
+
+// NewListViewSizeWarning creates a warning for list view
+func NewListViewSizeWarning() *TerminalSizeWarning {
+	return NewTerminalSizeWarning(ListViewAbsoluteMinWidth, ListViewAbsoluteMinHeight, ListViewMinRecommendedWidth, ListViewMinRecommendedHeight)
+}
+
+// IsTooSmall checks if the terminal size is below minimum
+func (w *TerminalSizeWarning) IsTooSmall(width, height int) bool {
+	return width < w.minWidth || height < w.minHeight
+}
+
+// IsDismissed returns whether the warning has been dismissed
+func (w *TerminalSizeWarning) IsDismissed() bool {
+	return w.dismissed
+}
+
+// Dismiss marks the warning as dismissed
+func (w *TerminalSizeWarning) Dismiss() {
+	w.dismissed = true
+}
+
+// Reset resets the dismissed state (useful when window becomes large then small again)
+func (w *TerminalSizeWarning) Reset() {
+	w.dismissed = false
+}
+
+// ShouldShow returns true if the warning should be displayed
+func (w *TerminalSizeWarning) ShouldShow(width, height int) bool {
+	return w.IsTooSmall(width, height) && !w.dismissed
+}
+
+// View renders the warning overlay
+func (w *TerminalSizeWarning) View(width, height int) string {
+	contentWidth := width - 8 // 4 for padding (2 on each side) + 4 for borders and margins
+	contentWidth = max(contentWidth, 40)
+
+	warningBox := styles.WarningBoxStyle.Align(lipgloss.Center)
+	warningText := styles.WarningStyle.Bold(true).Render("WARNING: Window too small")
+
+	center := styles.TextCenterStyle.Width(contentWidth)
+
+	content := []string{
+		center.Render(warningText),
+		"",
+		center.Render("Please resize your terminal window to view the contents properly."),
+		"",
+		center.Render(fmt.Sprintf("Current size: %d × %d", width, height)),
+		center.Render(fmt.Sprintf("Recommended: %d × %d or larger", w.recommendedWidth, w.recommendedHeight)),
+		"",
+		center.Render(styles.DimStyle.Render("Press Enter or d to dismiss and show anyway")),
+		center.Render(styles.DimStyle.Render("Press q to quit")),
+	}
+
+	boxContent := lipgloss.JoinVertical(lipgloss.Left, content...)
+	box := warningBox.Render(boxContent)
+
+	verticalPadding := (height - lipgloss.Height(box)) / 2
+	if verticalPadding > 0 {
+		padding := strings.Repeat("\n", verticalPadding)
+		return padding + box
+	}
+
+	return box
+}

--- a/internal/tui/onboard/view.go
+++ b/internal/tui/onboard/view.go
@@ -81,7 +81,7 @@ func (m *Model) View() string {
 		yamlStr := formatYAMLWithBlankLines([]byte(buf.String()))
 
 		// Render boxed YAML (actual viewport content)
-		content := styles.BoxStyle.Render(string(yamlStr))
+		content := styles.InfoBoxStyle.Render(string(yamlStr))
 		contentHeight := lipgloss.Height(content)
 
 		// Measure layout pieces
@@ -165,7 +165,7 @@ func (m *Model) View() string {
 
 		if len(def) > 60 || strings.Contains(def, "\n") || strings.Contains(def, "\\") {
 			body.WriteString(styles.DimStyle.Render("Default value:") + "\n")
-			body.WriteString(styles.BoxStyle.Render(def) + "\n\n")
+			body.WriteString(styles.InfoBoxStyle.Render(def) + "\n\n")
 			body.WriteString(styles.DimStyle.Render("Press enter to use default, or type your custom command:") + "\n")
 		} else {
 			body.WriteString(styles.DimStyle.Render("Default value: "+def) + "\n")

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -17,6 +17,8 @@ var (
 	}()
 
 	SecondaryColor = "55"
+
+	WarningColor = "214"
 )
 
 var (
@@ -37,7 +39,7 @@ var (
 			Foreground(lipgloss.Color("196"))
 
 	WarningStyle = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("214"))
+			Foreground(lipgloss.Color(WarningColor))
 
 	DimStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("245"))
@@ -62,8 +64,15 @@ var (
 
 	BoxStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
-			BorderForeground(lipgloss.Color(PrimaryColor)).
 			Padding(1, 2)
+
+	InfoBoxStyle = BoxStyle.
+			BorderForeground(lipgloss.Color(PrimaryColor))
+
+	WarningBoxStyle = BoxStyle.
+			BorderForeground(lipgloss.Color(WarningColor))
+
+	TextCenterStyle = lipgloss.NewStyle().Align(lipgloss.Center)
 
 	InputStyle = lipgloss.NewStyle().
 			BorderStyle(lipgloss.NormalBorder()).


### PR DESCRIPTION
Improve the TUI experience when running in narrow or small terminal windows by adding size warnings, informational messages, and proper text truncation.

## Changes

### Terminal Size Warning

- Added dismissible warning overlay for terminals below minimum size thresholds
- Users can press `Enter` or `d` to dismiss and view content anyway
- Warning reappears if window is resized from large → small
- Separate minimum sizes for test execution view (60×25) and list view (55×15)
- Recommended sizes: 150×40 for test execution, 140×20 for list view

### Narrow Terminal Improvements

- **Test executor view**: Shows informational message in vertical layout mode (width < 100)
  - Explains vertical layout is enabled due to narrow terminal
  - Suggests expanding window for horizontal layout
- **List view**: Shows informational message when narrow (width < 140)
  - Notes that some columns may be truncated
  - Suggests expanding for better visibility
- Help text now truncates with ellipsis (`...`) when it doesn't fit terminal width (`TruncateWithEllipsis()`)

### Layout Fixes

- Fixed log panel rendering issues at narrow widths (changed `Width` → `MaxWidth`)
- Improved vertical layout spacing calculations using actual component heights
- Added visual separation between table and log panel in vertical mode
- Footer now properly anchored to bottom of terminal

### Style Updates

- Minor style updates: split `BoxStyle` into `InfoBoxStyle` (primary color) and `WarningBoxStyle` (warning color), added `TextCenterStyle` for consistent text centering