### PR TITLE
fix: allow dotenv config overrides

### DIFF
--- a/internal/runner/service.go
+++ b/internal/runner/service.go
@@ -71,6 +71,12 @@ func (e *Executor) StartService() error {
 	}
 
 	env = append(env, "TUSK_DRIFT_MODE=REPLAY")
+	// Force dotenv to override inherited environment variables.
+	// Since main.go loads .env into Tusk's process (via godotenv.Load()), those variables
+	// get inherited by the service through os.Environ(). By default, Node.js dotenv will
+	// NOT override existing env vars, which means DOTENV_CONFIG_PATH (if set) won't work as expected.
+	// Setting DOTENV_CONFIG_OVERRIDE=true ensures dotenv respects DOTENV_CONFIG_PATH and overrides any inherited values
+	env = append(env, "DOTENV_CONFIG_OVERRIDE=true")
 	e.serviceCmd.Env = env
 
 	// Dump service logs to file in .tusk/logs instead of suppressing


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Set `DOTENV_CONFIG_OVERRIDE=true` in service env so Node dotenv overrides inherited variables and respects `DOTENV_CONFIG_PATH`.
> 
> - **Runner / Service startup (`internal/runner/service.go`)**:
>   - Append `DOTENV_CONFIG_OVERRIDE=true` to `e.serviceCmd.Env` after `TUSK_DRIFT_MODE=REPLAY`.
>   - Ensures Node dotenv overrides inherited env vars and honors `DOTENV_CONFIG_PATH` during service start.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f4e17a67bb5cce539859741cc92424b3472fbfc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->