### PR TITLE
fix: avoid loading env file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ go clean -modcache
 
 ### Development environment variables
 
-Create a `.env` file and add your environment variables.
+Set required env vars in your shell if necessary. To avoid potential conflicts with the service's env vars when running tests locally, this CLI doesn't load from `.env`.
 
 Testing auth to Tusk dev:
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.9
 	github.com/charmbracelet/glamour v0.10.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
-	github.com/joho/godotenv v1.5.1
 	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/file v1.2.0
 	github.com/knadh/koanf/v2 v2.2.2

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,6 @@ github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUq
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
-github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/knadh/koanf/maps v0.1.2 h1:RBfmAW5CnZT+PJ1CVc1QSJKf4Xu9kxfQgYVQSu8hpbo=
 github.com/knadh/koanf/maps v0.1.2/go.mod h1:npD/QZY3V6ghQDdcQzl1W4ICNVTkohC8E73eI2xW4yI=
 github.com/knadh/koanf/parsers/yaml v1.1.0 h1:3ltfm9ljprAHt4jxgeYLlFPmUaunuCgu1yILuTXRdM4=

--- a/main.go
+++ b/main.go
@@ -1,20 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/Use-Tusk/tusk-drift-cli/cmd"
-	"github.com/joho/godotenv"
 )
 
 func main() {
-	err := godotenv.Load()
-	if err != nil && !os.IsNotExist(err) {
-		fmt.Printf("Error loading .env file: %v\n", err)
-		os.Exit(1)
-	}
-
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
Currently, the CLI reads from a `.env` file for development env vars (e.g. those relating to Auth0). At the time it was written, it was meant for the running auth commands in the CLI's directory.

To avoid conflicts with the env vars of the service under tests (which could be in an `.env` file) when run in said service's directory, CLI will not read an `.env` file on start.

The other alternative is to remove `env := os.Environ()` but that may inadvertently remove required env vars like PATH etc.

When special env vars need to be injected for testing purposes, developers shall set env vars in the shell instead.

