### PR TITLE
fix: move trace data cleanup after upload callback

### DIFF
--- a/internal/runner/executor.go
+++ b/internal/runner/executor.go
@@ -442,7 +442,6 @@ func (e *Executor) RunSingleTest(test Test) (TestResult, error) {
 		// Help attribute outbound events to this test when SDK omits testId
 		e.server.SetCurrentTestID(test.TraceID)
 		defer e.server.SetCurrentTestID("")
-		defer e.server.CleanupTraceSpans(test.TraceID)
 	}
 
 	var reqBody io.Reader


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Defers trace span cleanup until after per-test completion callbacks (including cloud upload), removing early cleanup in executor and adding a default cleanup callback, plus a regression test to prevent missing upload data.
> 
> - **Runner lifecycle**:
>   - Move `server.CleanupTraceSpans` from `executor.RunSingleTest` (removed defer) to `OnTestCompleted` callbacks in `cmd/run.go`.
>   - In cloud upload path, perform cleanup after `UploadSingleTestResult` and existing output callback.
>   - Add default `OnTestCompleted` that only cleans up spans when no other callback is set.
> - **Tests**:
>   - Add `TestRunTests_UploadMissingDataDueToRaceCondition` to ensure span results (incl. root span ID) are available to upload, and spans are cleaned afterward.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ac9b37e03da0c734e7d6b1352b33e1aa45a15e1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->