### PR TITLE
fix: only include traces with a root span

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -731,12 +731,20 @@ func makeLoadTestsFunc(
 			case traceDir != "":
 				tests, err = executor.LoadTestsFromFolder(traceDir)
 			case traceFile != "":
-				tests, err = executor.LoadTestsFromTraceFile(traceFile)
+				var test *runner.Test
+				test, err = executor.LoadTestFromTraceFile(traceFile)
+				if test != nil {
+					tests = []runner.Test{*test}
+				}
 			case traceID != "":
 				var traceFilePath string
 				traceFilePath, err = utils.FindTraceFile(traceID, "")
 				if err == nil {
-					tests, err = executor.LoadTestsFromTraceFile(traceFilePath)
+					var test *runner.Test
+					test, err = executor.LoadTestFromTraceFile(traceFilePath)
+					if test != nil {
+						tests = []runner.Test{*test}
+					}
 				}
 			default:
 				tests, err = executor.LoadTestsFromFolder(utils.GetTracesDir())

--- a/internal/runner/test_loading_test.go
+++ b/internal/runner/test_loading_test.go
@@ -199,11 +199,11 @@ func TestExecutorLoadTestsFromFolderPropagatesParseErrors(t *testing.T) {
 	assert.Nil(t, tests)
 }
 
-func TestExecutorLoadTestsFromTraceFileReturnsErrorOnMalformed(t *testing.T) {
+func TestExecutorLoadTestFromTraceFileReturnsErrorOnMalformed(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "bad.jsonl")
 	require.NoError(t, os.WriteFile(path, []byte("{bad"), 0o600))
 
-	_, err := (&Executor{}).LoadTestsFromTraceFile(path)
+	_, err := (&Executor{}).LoadTestFromTraceFile(path)
 	require.Error(t, err)
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches local test loading to one test per trace file based on the root span, updating callers and tests accordingly.
> 
> - **Runner**:
>   - Replace `LoadTestsFromTraceFile` with `LoadTestFromTraceFile` returning a single `*Test` per `.jsonl` file, using the root span; returns `nil` if no root span.
>   - `LoadTestsFromFolder` updated to collect single tests and skip files without a root span.
>   - Simplify root span selection and set `test.Spans` to all spans from the file.
> - **CLI (`cmd/run.go`)**:
>   - Update loading logic to use `LoadTestFromTraceFile` for `--trace-file` and `--trace-id`, wrapping non-nil results into `[]runner.Test`.
> - **Tests**:
>   - Adjust unit tests to new single-test loader and rename test to `LoadTestFromTraceFile` where applicable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d4d38fbaf0454c716acd8fe2ce2fda4eaa2142f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->