### PR TITLE
fix: TUI issues

### DIFF
--- a/internal/tui/test_executor.go
+++ b/internal/tui/test_executor.go
@@ -625,7 +625,7 @@ func (m *testExecutorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *testExecutorModel) handleTableNavigation(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "up", "down":
+	case "up", "down", "j", "k":
 		cmd := m.testTable.Update(msg)
 
 		// Update log panel based on selection
@@ -637,7 +637,7 @@ func (m *testExecutorModel) handleTableNavigation(msg tea.KeyMsg) (tea.Model, te
 
 		return m, cmd
 
-	case "right":
+	case "right", "l":
 		m.viewMode = logNavigation
 		m.testTable.SetFocused(false)
 		m.logPanel.SetFocused(true)
@@ -659,19 +659,19 @@ func (m *testExecutorModel) handleTableNavigation(msg tea.KeyMsg) (tea.Model, te
 
 func (m *testExecutorModel) handleLogNavigation(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
-	case "up", "down", "pgup", "pgdown", "g", "G":
+	case "up", "down", "pgup", "pgdown", "g", "G", "j", "k":
 		return m, m.logPanel.Update(msg)
 
 	case "y":
 		return m, m.copyLogsToClipboard()
 
-	case "c":
+	case "f":
 		m.viewMode = logCopyMode
 		m.copyModeViewport = viewport.Model{}
 
 		return m, nil
 
-	case "left", "esc":
+	case "left", "esc", "h":
 		m.viewMode = tableNavigation
 		m.testTable.SetFocused(true)
 		m.logPanel.SetFocused(false)
@@ -692,6 +692,14 @@ func (m *testExecutorModel) handleLogCopyMode(msg tea.KeyMsg) (tea.Model, tea.Cm
 		m.copyModeViewport, cmd = m.copyModeViewport.Update(msg)
 		return m, cmd
 
+	case "j":
+		m.copyModeViewport.ScrollDown(1)
+		return m, nil
+
+	case "k":
+		m.copyModeViewport.ScrollUp(1)
+		return m, nil
+
 	case "g":
 		m.copyModeViewport.GotoTop()
 
@@ -701,7 +709,7 @@ func (m *testExecutorModel) handleLogCopyMode(msg tea.KeyMsg) (tea.Model, tea.Cm
 	case "y":
 		return m, m.copyLogsToClipboard()
 
-	case "esc", "c":
+	case "esc", "f":
 		m.viewMode = logNavigation
 		return m, nil
 
@@ -716,11 +724,11 @@ func (m *testExecutorModel) handleLogCopyMode(msg tea.KeyMsg) (tea.Model, tea.Cm
 func (m *testExecutorModel) getFooterText() string {
 	switch m.viewMode {
 	case tableNavigation:
-		return "↑/↓: navigate • g: go to top • G: go to bottom • →: view logs • q: quit"
+		return "↑/↓/j/k: navigate • g: go to top • G: go to bottom • →/l: view logs • q: quit"
 	case logNavigation:
-		return "↑/↓: scroll logs • g: go to top • G: go to bottom • y: copy • c: full screen mode • ←/Esc: back to table • q: quit"
+		return "↑/↓/j/k: scroll • g: go to top • G: go to bottom • y: copy • f: full screen • ←/h/Esc: back to table • q: quit"
 	case logCopyMode:
-		return "FULL SCREEN MODE • g: go to top • G: go to bottom • y: copy • c/Esc: exit full screen • q: quit"
+		return "FULL SCREEN MODE • ↑/↓/j/k: scroll • g: go to top • G: go to bottom • y: copy • f/Esc: exit full screen • q: quit"
 	default:
 		return ""
 	}

--- a/internal/utils/text.go
+++ b/internal/utils/text.go
@@ -26,14 +26,14 @@ func StripNoWrapMarker(text string) string {
 // ANSI color code regex pattern
 var ansiRegex = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
-// stripANSI removes ANSI escape sequences from a string
-func stripANSI(s string) string {
+// StripANSI removes ANSI escape sequences from a string
+func StripANSI(s string) string {
 	return ansiRegex.ReplaceAllString(s, "")
 }
 
 // visibleLen returns the visible length of a string (excluding ANSI codes)
 func visibleLen(s string) int {
-	return len(stripANSI(s))
+	return len(StripANSI(s))
 }
 
 // WrapLine wraps a single line of text to the specified width, trying to break at word boundaries
@@ -140,7 +140,7 @@ func splitLongWord(word string, maxWidth int) []string {
 
 	// For simplicity with ANSI codes, we'll strip them, split, then try to preserve
 	// This is a basic implementation that works for most cases
-	stripped := stripANSI(word)
+	stripped := StripANSI(word)
 	if len(stripped) <= maxWidth {
 		return []string{word}
 	}
@@ -301,7 +301,7 @@ func formatJSONForDiff(v any) string {
 }
 
 func TruncateWithEllipsis(text string, maxWidth int) string {
-	visibleLength := runewidth.StringWidth(stripANSI(text))
+	visibleLength := runewidth.StringWidth(StripANSI(text))
 
 	if visibleLength <= maxWidth {
 		return text

--- a/internal/utils/text_test.go
+++ b/internal/utils/text_test.go
@@ -134,7 +134,7 @@ func TestFormatJSONDiff_DifferentValues(t *testing.T) {
 
 	for _, line := range lines {
 		// Strip both ANSI codes and the NoWrapMarker before checking
-		stripped := StripNoWrapMarker(stripANSI(line))
+		stripped := StripNoWrapMarker(StripANSI(line))
 		trimmed := strings.TrimSpace(stripped)
 
 		if strings.HasPrefix(trimmed, "-") && strings.Contains(line, "value1") {
@@ -175,7 +175,7 @@ func TestTruncateWithEllipsis_WithANSICodes(t *testing.T) {
 	text := red + "hello" + reset + " " + green + "world" + reset + " test"
 
 	got := TruncateWithEllipsis(text, 10)
-	visibleText := stripANSI(got)
+	visibleText := StripANSI(got)
 	assert.Equal(t, 10, len(visibleText), "visible length should be exactly maxWidth")
 	assert.True(t, strings.HasSuffix(visibleText, "..."), "should end with ellipsis")
 }
@@ -188,7 +188,7 @@ func TestTruncateWithEllipsis_UTF8MultibyteCharacters(t *testing.T) {
 
 	// When dealing with wide characters, we might not hit exactly maxWidth
 	// because we can't split a 2-column character
-	visibleLen := runewidth.StringWidth(stripANSI(got))
+	visibleLen := runewidth.StringWidth(StripANSI(got))
 	assert.LessOrEqual(t, visibleLen, 10, "visible length should not exceed maxWidth")
 	assert.GreaterOrEqual(t, visibleLen, 10-2, "visible length should be close to maxWidth (within 2 columns for wide chars)")
 
@@ -215,8 +215,8 @@ func TestTruncateWithEllipsis_ANSIAtTruncationPoint(t *testing.T) {
 	text := "hello" + red + " world" + reset
 
 	got := TruncateWithEllipsis(text, 8)
-	assert.True(t, strings.HasSuffix(stripANSI(got), "..."), "should end with ellipsis")
+	assert.True(t, strings.HasSuffix(StripANSI(got), "..."), "should end with ellipsis")
 
-	visibleText := stripANSI(got)
+	visibleText := StripANSI(got)
 	assert.Equal(t, 8, len(visibleText), "visible length should be maxWidth")
 }


### PR DESCRIPTION
### Changes

- Fix issue of not being able to scroll on test log panel. This is caused by `viewport.GotoBottom()` being called on every `View()` (which happens every keypress), fixed by providing an option for `updateViewport()` whether to go to bottom.
- Fix copy action excluding the diff of the response body in deviations. This is caused by the no-wrap marker truncating the text, fixed by stripping the marker before copying.
- Added h/j/k/l keybindings to TUI