### PR TITLE
test: add e2e test

### DIFF
--- a/.github/workflows/e2e-node.yml
+++ b/.github/workflows/e2e-node.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: E2E Tests (Node.js)
 
 on:
   push:
@@ -40,7 +40,7 @@ jobs:
         working-directory: ../drift-node-demo
         run: npm ci
 
-      - name: Run E2E tests
+      - name: Run Node.js E2E tests
         working-directory: ../drift-node-demo
         run: |
           $GITHUB_WORKSPACE/tusk run --print


### PR DESCRIPTION
Add an end-to-end test with `drift-node-demo` repo.

This tests the basic functionality of the CLI - the demo makes simple requests and these should all pass.