### PR TITLE
fix: don't show analytics notice if analytics disable is cmd

### DIFF
--- a/internal/analytics/notice.go
+++ b/internal/analytics/notice.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/Use-Tusk/tusk-drift-cli/internal/cliconfig"
+	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
 
@@ -16,7 +17,12 @@ To disable: export TUSK_ANALYTICS_DISABLED=1 or run: tusk analytics disable`
 
 // ShowFirstRunNotice displays the analytics notice on first run
 // Returns true if the notice was shown (and we should track first_run)
-func ShowFirstRunNotice() bool {
+func ShowFirstRunNotice(cmd *cobra.Command) bool {
+	// Skip if user is running "analytics disable" - don't show notice when they're trying to disable
+	if getCommandPath(cmd) == "analytics disable" {
+		return false
+	}
+
 	// Skip if analytics is disabled (includes CI check)
 	if !cliconfig.IsAnalyticsEnabled() {
 		return false

--- a/internal/analytics/tracker.go
+++ b/internal/analytics/tracker.go
@@ -24,7 +24,7 @@ func NewTracker(cmd *cobra.Command) *Tracker {
 	}
 
 	// Check if we need to show first-run notice (before creating client)
-	firstRun := ShowFirstRunNotice()
+	firstRun := ShowFirstRunNotice(cmd)
 
 	client := NewClient()
 	if client == nil {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Prevents displaying the first-run analytics notice when the user runs `analytics disable`.
> 
> - Change `ShowFirstRunNotice` to accept `*cobra.Command` and return early if the command path is `analytics disable`
> - Update `NewTracker` to pass `cmd` into `ShowFirstRunNotice`
> - Add `cobra` import in `notice.go`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59bfb46127de64795673450f2225a6cd7a628d59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->