### PR TITLE
Fix invalid filter error in trace replay

### DIFF
--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -393,7 +393,7 @@ func toolDefinitions() map[ToolName]*ToolDefinition {
 				"properties": {
 					"filter": {
 						"type": "string",
-						"description": "Optional filter pattern for traces (regex)"
+						"description": "Optional filter using key=regex format. Keys: path, type, op, method, name, id. Examples: 'path=/api/users', 'type=GRAPHQL,op=^GetUser$', 'method=POST,path=/checkout'. Omit to run all tests."
 					},
 					"debug": {
 						"type": "boolean",


### PR DESCRIPTION
The filter parameter description was too vague ("Optional filter pattern for traces (regex)"), causing LLMs to generate non-fielded filters like "/api/ai/moderate" instead of the required "path=/api/ai/moderate" format.

Updated description to include:
- The required key=regex format
- Available filter keys (path, type, op, method, name, id)
- Concrete examples
- Note that omitting filter runs all tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies the `filter` parameter for `ToolTuskRun` to require `key=regex`, lists allowed keys (`path`, `type`, `op`, `method`, `name`, `id`), provides concrete examples, and notes that omitting `filter` runs all tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cac1de1aa0f8a9a31f0376a58fc3ad91046f61d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->