### PR TITLE
fix: remove sandboxing options from onboarding agent

### DIFF
--- a/cmd/exp_setup.go
+++ b/cmd/exp_setup.go
@@ -14,7 +14,6 @@ var (
 	expAPIKey          string
 	expModel           string
 	expSkipPermissions bool
-	expDisableSandbox  bool
 	expDisableProgress bool
 	expSkipToCloud     bool
 	expPrintMode       bool
@@ -51,7 +50,6 @@ func init() {
 	expSetupCmd.Flags().StringVar(&expAPIKey, "api-key", "", "Anthropic API key (or set ANTHROPIC_API_KEY env var)")
 	expSetupCmd.Flags().StringVar(&expModel, "model", "claude-sonnet-4-20250514", "Claude model to use")
 	expSetupCmd.Flags().BoolVar(&expSkipPermissions, "skip-permissions", false, "Skip permission prompts for consequential actions (commands, file writes, etc.)")
-	expSetupCmd.Flags().BoolVar(&expDisableSandbox, "disable-sandbox", false, "Disable command sandboxing (for MacOS/Linux only)")
 	expSetupCmd.Flags().BoolVar(&expDisableProgress, "disable-progress-state", false, "Disable progress state (saving to a PROGRESS.md file) or resuming from it")
 	expSetupCmd.Flags().BoolVar(&expSkipToCloud, "skip-to-cloud", false, "Skip local setup and go directly to cloud setup (for testing)")
 	expSetupCmd.Flags().BoolVar(&expPrintMode, "print", false, "Headless mode - no TUI, stream output to stdout")
@@ -90,10 +88,8 @@ func runExpSetup(cmd *cobra.Command, args []string) error {
 		Model:           expModel,
 		WorkDir:         workDir,
 		SkipPermissions: expSkipPermissions,
-		DisableSandbox:  expDisableSandbox,
 		DisableProgress: expDisableProgress,
 		SkipToCloud:     expSkipToCloud,
-		Debug:           debug,
 		PrintMode:       expPrintMode,
 		OutputLogs:      expOutputLogs,
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -88,7 +88,7 @@ func New(cfg Config) (*Agent, error) {
 		return nil, err
 	}
 
-	pm := NewProcessManagerWithOptions(cfg.WorkDir, cfg.DisableSandbox, cfg.Debug)
+	pm := NewProcessManager(cfg.WorkDir)
 	phaseMgr := NewPhaseManager()
 
 	// If skipping to cloud, start with cloud phases only

--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -753,8 +753,3 @@ type ProcessManager = tools.ProcessManager
 func NewProcessManager(workDir string) *ProcessManager {
 	return tools.NewProcessManager(workDir)
 }
-
-// NewProcessManagerWithOptions creates a new ProcessManager with options
-func NewProcessManagerWithOptions(workDir string, disableSandbox bool, debug bool) *ProcessManager {
-	return tools.NewProcessManagerWithOptions(workDir, disableSandbox, debug)
-}

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -117,10 +117,8 @@ type Config struct {
 	MaxTokens       int
 	WorkDir         string
 	SkipPermissions bool // Skip permission prompts for consequential actions
-	DisableSandbox  bool // Disable fence sandboxing for commands
 	DisableProgress bool // Don't save or resume from PROGRESS.md
 	SkipToCloud     bool // Skip local setup and go directly to cloud setup (for testing)
-	Debug           bool // Enable debug mode for fence sandbox
 	PrintMode       bool // Headless mode - no TUI, stream to stdout
 	OutputLogs      bool // Output all logs to a file in .tusk/logs/
 }


### PR DESCRIPTION
### Issue 

The setup agent's fence sandbox could fail at `npm install` and similar commands, possibly due to:
- Non-existent cache directories being skipped (e.g., `~/.npm` not pre-created)
- Custom npm cache locations not being whitelisted
- Overly restrictive filesystem access during package installation

### Solution

Remove fence sandboxing for agent `run_command` operations. This is a reasonable trade-off because:

- `start_background_process` was already unsandboxed (for record/confirm phases)
- `validateCommandSafety()` still blocks dangerous commands (rm -rf, sudo, git push, etc.)
- **Replay sandboxing is preserved** via `runner.createReplayFenceConfig()` — this is the critical path that blocks localhost outbound to detect uninstrumented packages

### Changes

- Remove fence initialization and wrapping from `ProcessManager`
- Remove `--disable-sandbox` flag and `Debug` config
- Simplify `NewProcessManager()` API