### PR TITLE
ci: add python demo repo as e2e test

### DIFF
--- a/.github/workflows/e2e-python.yml
+++ b/.github/workflows/e2e-python.yml
@@ -60,15 +60,3 @@ jobs:
           source venv/bin/activate
           $GITHUB_WORKSPACE/tusk run --print --enable-service-logs
           # Exits non-zero if any test has deviations
-
-      - name: Print first log file
-        if: always()
-        working-directory: ../drift-python-demo
-        run: |
-          FIRST_LOG=$(ls -1 .tusk/logs/*.log 2>/dev/null | head -n 1)
-          if [ -n "$FIRST_LOG" ]; then
-            echo "=== Contents of $FIRST_LOG ==="
-            cat "$FIRST_LOG"
-          else
-            echo "No log files found in .tusk/logs/"
-          fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new GitHub Actions workflow to run Python E2E tests against the demo repo across Linux and macOS.
> 
> - New `/.github/workflows/e2e-python.yml` runs on push/PR to `main` with a matrix of `ubuntu-latest` and `macos-latest`
> - Builds the Go CLI, sets up Python 3.12, clones `drift-python-demo`, installs deps, and executes `tusk run --print --enable-service-logs`
> - On Linux runners, installs sandbox tools (`bubblewrap`, `socat`, `uidmap`) and configures `subuid/subgid` and setuid `bwrap`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9c5be8abe2d9bd3e4c792cedfbae2600dbbcb45a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->