### PR TITLE
feat: filter local traces with HTTP status >= 300 from replay execution

### DIFF
--- a/internal/runner/filter.go
+++ b/internal/runner/filter.go
@@ -171,3 +171,17 @@ func extractGraphQLOperationName(displayName string) string {
 	}
 	return displayName
 }
+
+// FilterLocalTestsForExecution filters out local tests with HTTP status >= 300.
+// These tests are skipped for replay but their spans remain available for mock matching.
+// Returns (testsToExecute, excludedCount).
+func FilterLocalTestsForExecution(tests []Test) (testsToExecute []Test, excludedCount int) {
+	for _, t := range tests {
+		if t.Response.Status >= 300 {
+			excludedCount++
+			continue
+		}
+		testsToExecute = append(testsToExecute, t)
+	}
+	return testsToExecute, excludedCount
+}


### PR DESCRIPTION
### Summary

When replaying local traces, automatically skip tests where the server span has HTTP status code >= 300, while keeping their spans available for mock matching.

### Motivation

The SDK now only filters traces with status >= 400 (previously >= 300). This means 3xx responses (redirects, etc.) are now captured in local traces. However, Tusk often has trouble reliably replaying these 300-level traces and we don't want the onboarding agent to get confused with such traces.

For cloud mode, this isn't an issue because traces are validated on main before being added to the test suite. But for local traces, we need to filter these out to avoid flaky test failures while still allowing the mock matching algorithm to use them as mocks for other tests.

### Changes

- Add `FilterLocalTestsForExecution()` function in `internal/runner/filter.go` that filters out tests with HTTP status >= 300
- Modify non-interactive flow in `cmd/run.go` to:
  - Build suite spans with ALL tests first (so spans from 3xx/4xx/5xx traces are available for mock matching)
  - Then filter out status >= 300 tests for execution only
- Modify interactive flow in `cmd/run.go` to:
  - Store all tests before filtering for suite span preparation
  - Return filtered tests for TUI display/execution
  - Use unfiltered tests in `OnBeforeEnvironmentStart` for mock matching

### Behavior

| Mode | Test Execution | Suite Spans (for mocking) |
|------|----------------|---------------------------|
| Local | Skip status >= 300 | Include ALL tests |
| Cloud | No filtering | Include ALL tests |

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Filters local tests with HTTP status >= 300 from execution while still preparing suite spans using all tests for mock matching.
> 
> - Non-interactive: call `PrepareAndSetSuiteSpans` with ALL local tests, then apply `runner.FilterLocalTestsForExecution()`; log skipped count
> - Interactive: store unfiltered tests during load, return filtered tests for display/execution, and use unfiltered in `OnBeforeEnvironmentStart` for span prep
> - Cloud mode unchanged (no auto-filtering); suite spans still built from all tests
> - New helper `runner.FilterLocalTestsForExecution()` added in `internal/runner/filter.go`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a72ae4349ae7c6ba34b7be0d8b7b73524bdf7fe8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->