### PR TITLE
docs: update README for recent setup agent changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ Use our AI agent to automatically set up Tusk Drift for your service:
 
 ```bash
 cd path/to/your/service
-export ANTHROPIC_API_KEY=your-api-key
 tusk setup
 ```
 


### PR DESCRIPTION
Now that we have proxying, `ANTHROPIC_API_KEY` is not longer required to be set.