### PR TITLE
chore: update fence to v0.1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Use-Tusk/tusk-drift-cli
 go 1.25.0
 
 require (
-	github.com/Use-Tusk/fence v0.1.5
+	github.com/Use-Tusk/fence v0.1.16
 	github.com/Use-Tusk/tusk-drift-schemas v0.1.24
 	github.com/agnivade/levenshtein v1.0.3
 	github.com/atotto/clipboard v0.1.4
@@ -65,6 +65,7 @@ require (
 	github.com/muesli/cancelreader v0.2.2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/things-go/go-socks5 v0.0.5 // indirect
+	github.com/tidwall/jsonc v0.3.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yuin/goldmark v1.7.8 // indirect
 	github.com/yuin/goldmark-emoji v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
-github.com/Use-Tusk/fence v0.1.5 h1:plOPBX2uqJK50MJEVKeigFv8INYEV783LMVz1cMMa5E=
-github.com/Use-Tusk/fence v0.1.5/go.mod h1:HQQjPkpRKkapla8wSXuTkaHVCXh5zSZTiAHnBy+Xxvg=
+github.com/Use-Tusk/fence v0.1.16 h1:iTHn7ttCbvUANZ9Bo/3HyZYAw7ZrNAjoZjaX7kDbE0I=
+github.com/Use-Tusk/fence v0.1.16/go.mod h1:topOkP7EULI+78u+Ax775d36GqWfx2BhqkVEQ/QXXAU=
 github.com/Use-Tusk/tusk-drift-schemas v0.1.24 h1:q5rdVm46qk+6s7THk1QeSYDJc+/nL63ChyEYF/VxaTM=
 github.com/Use-Tusk/tusk-drift-schemas v0.1.24/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
 github.com/agnivade/levenshtein v1.0.3 h1:M5ZnqLOoZR8ygVq0FfkXsNOKzMCk0xRiow0R5+5VkQ0=
@@ -144,6 +144,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/things-go/go-socks5 v0.0.5 h1:qvKaGcBkfDrUL33SchHN93srAmYGzb4CxSM2DPYufe8=
 github.com/things-go/go-socks5 v0.0.5/go.mod h1:mtzInf8v5xmsBpHZVbIw2YQYhc4K0jRwzfsH64Uh0IQ=
+github.com/tidwall/jsonc v0.3.2 h1:ZTKrmejRlAJYdn0kcaFqRAKlxxFIC21pYq8vLa4p2Wc=
+github.com/tidwall/jsonc v0.3.2/go.mod h1:dw+3CIxqHi+t8eFSpzzMlcVYxKp08UP5CD8/uSFCyJE=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/yuin/goldmark v1.7.1/go.mod h1:uzxRWxtg69N339t3louHJ7+O03ezfj6PlliRlaOzY1E=


### PR DESCRIPTION
### Summary

Updates fence dependency to v0.1.16 which fixes macOS sandbox `/tmp` access issues during replay mode.

### Changes

- Bump `github.com/Use-Tusk/fence` from v0.1.5 to v0.1.16

### Context

Fence v0.1.16 includes a fix for macOS where `/tmp` (a symlink to `/private/tmp`) could be blocked even when configured as writable. This was causing failures when running tools like `pnpm` under the sandbox during replay mode, as pnpm uses `TMPDIR` for caching operations.
