### PR TITLE
feat: add config validation tool for setup agent

### DIFF
--- a/internal/agent/executor.go
+++ b/internal/agent/executor.go
@@ -25,6 +25,7 @@ const (
 	ToolHTTPRequest            ToolName = "http_request"
 	ToolAskUser                ToolName = "ask_user"
 	ToolAskUserSelect          ToolName = "ask_user_select"
+	ToolTuskValidateConfig     ToolName = "tusk_validate_config"
 	ToolTuskList               ToolName = "tusk_list"
 	ToolTuskRun                ToolName = "tusk_run"
 	ToolTransitionPhase        ToolName = "transition_phase"
@@ -377,6 +378,14 @@ func toolDefinitions() map[ToolName]*ToolDefinition {
 				"required": ["question", "options"]
 			}`),
 		},
+		ToolTuskValidateConfig: {
+			Name:        ToolTuskValidateConfig,
+			Description: "Validate the .tusk/config.yaml file. ALWAYS call this after creating or modifying the config file to catch errors early. Returns validation results including any unknown keys, missing required fields, and schema hints.",
+			InputSchema: json.RawMessage(`{
+				"type": "object",
+				"properties": {}
+			}`),
+		},
 		ToolTuskList: {
 			Name:        ToolTuskList,
 			Description: "Run 'tusk list' to show available recorded traces. Use after recording to verify traces were captured.",
@@ -666,6 +675,7 @@ func RegisterTools(workDir string, pm *ProcessManager, phaseMgr *PhaseManager) (
 		ToolHTTPRequest:            http.Request,
 		ToolAskUser:                user.Ask,
 		ToolAskUserSelect:          nil, // Handled specially in agent.go like ask_user
+		ToolTuskValidateConfig:     tusk.ValidateConfig,
 		ToolTuskList:               tusk.List,
 		ToolTuskRun:                tusk.Run,
 		ToolTransitionPhase:        phaseMgr.PhaseTransitionTool(),

--- a/internal/agent/phases.go
+++ b/internal/agent/phases.go
@@ -541,6 +541,7 @@ func createConfigPhase() *Phase {
 		Tools: Tools(
 			ToolWriteFile,
 			ToolReadFile,
+			ToolTuskValidateConfig,
 			ToolAskUser,
 			ToolTransitionPhase,
 		),
@@ -560,6 +561,7 @@ func simpleTestPhase() *Phase {
 			ToolWaitForReady,
 			ToolGetProcessLogs,
 			ToolHTTPRequest,
+			ToolTuskValidateConfig,
 			ToolTuskList,
 			ToolTuskRun,
 			ToolReadFile,

--- a/internal/agent/prompts/phase_create_config.md
+++ b/internal/agent/prompts/phase_create_config.md
@@ -65,7 +65,17 @@ recording:
 
 Also create docker-compose.tusk-override.yml if using Docker Compose.
 
-IMPORTANT: Always ensure config files end with a trailing newline.
+IMPORTANT:
+
+- Always ensure config files end with a trailing newline.
+- After creating the config file, ALWAYS call `tusk_validate_config` to verify the config is valid.
+- If validation fails, check the error messages for unknown keys or missing required fields and fix them.
+
+Common config mistakes to avoid:
+
+- `start_command: "..."` should be `start: { command: "..." }` (nested structure)
+- `readiness_command: "..."` should be `readiness_check: { command: "..." }` (nested structure)
+- `port: 3000` at root level should be `service: { port: 3000 }` (under service section)
 
 When done, call transition_phase with:
 {

--- a/internal/agent/prompts/phase_simple_test.md
+++ b/internal/agent/prompts/phase_simple_test.md
@@ -46,6 +46,7 @@ If it fails:
 
 - Run with `debug: true` (keep running it in debug mode until it passes)
 - Check for errors in the output or in the logs (in .tusk/logs/). Logs only appear if `debug: true` is set.
+- If you see config-related errors (e.g., "no start command"), run `tusk_validate_config` to check for config issues
 - Try to fix issues and retry (max 3 attempts)
 - If still failing, ask the user for help
 

--- a/internal/agent/tools/tusk.go
+++ b/internal/agent/tools/tusk.go
@@ -31,6 +31,21 @@ func NewTuskTools(workDir string) *TuskTools {
 	return &TuskTools{workDir: workDir}
 }
 
+// ValidateConfig validates the .tusk/config.yaml file and returns detailed results.
+// This should be called after creating or modifying the config to catch errors early.
+func (tt *TuskTools) ValidateConfig(input json.RawMessage) (string, error) {
+	configPath := filepath.Join(tt.workDir, ".tusk", "config.yaml")
+
+	result := config.ValidateConfigFile(configPath)
+
+	jsonBytes, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal validation result: %w", err)
+	}
+
+	return string(jsonBytes), nil
+}
+
 // List loads and lists traces from the .tusk/traces directory
 func (tt *TuskTools) List(input json.RawMessage) (string, error) {
 	_ = config.Load(filepath.Join(tt.workDir, ".tusk", "config.yaml"))

--- a/internal/agent/tui.go
+++ b/internal/agent/tui.go
@@ -35,6 +35,7 @@ var toolDisplayNames = map[string]string{
 	"wait_for_ready":           "Wait for ready",
 	"http_request":             "HTTP request",
 	"ask_user":                 "Ask user",
+	"tusk_validate_config":     "Validate config",
 	"tusk_list":                "List traces",
 	"tusk_run":                 "Run tests",
 	"transition_phase":         "Complete phase",

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,141 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestValidateConfigFile_Valid(t *testing.T) {
+	tmpDir := t.TempDir()
+	tuskDir := filepath.Join(tmpDir, ".tusk")
+	_ = os.MkdirAll(tuskDir, 0o750)
+
+	validConfig := `service:
+  name: test-service
+  port: 3000
+  start:
+    command: npm start
+`
+	configPath := filepath.Join(tuskDir, "config.yaml")
+	_ = os.WriteFile(configPath, []byte(validConfig), 0o600)
+
+	result := ValidateConfigFile(configPath)
+
+	if !result.Valid {
+		t.Errorf("Expected valid config, got errors: %v", result.Errors)
+	}
+	if len(result.UnknownKeys) > 0 {
+		t.Errorf("Expected no unknown keys, got: %v", result.UnknownKeys)
+	}
+}
+
+func TestValidateConfigFile_UnknownKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	tuskDir := filepath.Join(tmpDir, ".tusk")
+	_ = os.MkdirAll(tuskDir, 0o750)
+	Invalidate()
+
+	// start_command is a common mistake - should be service.start.command
+	badConfig := `service:
+  name: test-service
+  port: 3000
+  start_command: npm start
+`
+	configPath := filepath.Join(tuskDir, "config.yaml")
+	_ = os.WriteFile(configPath, []byte(badConfig), 0o600)
+
+	result := ValidateConfigFile(configPath)
+
+	if len(result.UnknownKeys) == 0 {
+		t.Error("Expected unknown keys to be detected")
+	}
+
+	foundStartCommand := false
+	for _, key := range result.UnknownKeys {
+		if key == "service.start_command" {
+			foundStartCommand = true
+			break
+		}
+	}
+	if !foundStartCommand {
+		t.Errorf("Expected 'service.start_command' in unknown keys, got: %v", result.UnknownKeys)
+	}
+
+	// Should have a warning suggesting the correct key
+	if len(result.Warnings) == 0 {
+		t.Error("Expected warnings about unknown keys")
+	}
+}
+
+func TestValidateConfigFile_MissingRequired(t *testing.T) {
+	tmpDir := t.TempDir()
+	tuskDir := filepath.Join(tmpDir, ".tusk")
+	_ = os.MkdirAll(tuskDir, 0o750)
+	Invalidate()
+
+	// Missing start.command
+	missingConfig := `service:
+  name: test-service
+  port: 3000
+`
+	configPath := filepath.Join(tuskDir, "config.yaml")
+	_ = os.WriteFile(configPath, []byte(missingConfig), 0o600)
+
+	result := ValidateConfigFile(configPath)
+
+	if result.Valid {
+		t.Error("Expected invalid config due to missing start.command")
+	}
+
+	foundMissing := false
+	for _, key := range result.MissingKeys {
+		if key == "service.start.command" {
+			foundMissing = true
+			break
+		}
+	}
+	if !foundMissing {
+		t.Errorf("Expected 'service.start.command' in missing keys, got: %v", result.MissingKeys)
+	}
+}
+
+func TestValidateConfigFile_NotFound(t *testing.T) {
+	Invalidate()
+	result := ValidateConfigFile("/nonexistent/path/config.yaml")
+
+	if result.Valid {
+		t.Error("Expected invalid result for nonexistent file")
+	}
+	if len(result.Errors) == 0 {
+		t.Error("Expected error message for nonexistent file")
+	}
+}
+
+func TestCheckUnknownKeys(t *testing.T) {
+	// Test that our valid key extraction works
+	validKeys := getValidKeys(reflect.TypeOf(Config{}), "")
+
+	// Should include nested keys
+	expectedKeys := []string{
+		"service",
+		"service.name",
+		"service.port",
+		"service.start",
+		"service.start.command",
+		"service.readiness_check",
+		"service.readiness_check.command",
+	}
+
+	keySet := make(map[string]bool)
+	for _, k := range validKeys {
+		keySet[k] = true
+	}
+
+	for _, expected := range expectedKeys {
+		if !keySet[expected] {
+			t.Errorf("Expected valid key %q not found in: %v", expected, validKeys)
+		}
+	}
+}


### PR DESCRIPTION
### Summary

Adds a `tusk_validate_config` tool that the setup agent can use to validate `.tusk/config.yaml` after creating or modifying it. This catches config mistakes early, before they cause cryptic failures during replay.

### Problem

There was an occurrence there the agent generated a config with `start_command` at the top level instead of the correct nested `service.start.command`. Because koanf silently ignores unknown keys, this resulted in an empty start command and a confusing "no start command" error during replay.

### Changes

- Add `ValidateConfigFile()`, `CheckUnknownKeys()`, `CheckRequiredForReplay()` to config package
- Add `tusk_validate_config` tool to agent tool registry
- Add tool to `create_config` and `simple_test` phases
- Update `phase_create_config.md` prompt with validation instructions and common mistakes
- Update `phase_simple_test.md` prompt with config validation troubleshooting tip
- Add tests for validation logic
