### PR TITLE
feat: auto-update .gitignore in setup agent

### DIFF
--- a/internal/agent/phases.go
+++ b/internal/agent/phases.go
@@ -749,6 +749,8 @@ func cloudConfigureRecordingPhase() *Phase {
 		Instructions: PhaseCloudConfigureRecordingPrompt,
 		Tools: Tools(
 			ToolCloudSaveConfig,
+			ToolReadFile,
+			ToolWriteFile,
 			ToolAskUser,
 			ToolTransitionPhase,
 		),

--- a/internal/agent/prompts/phase_cloud_configure_recording.md
+++ b/internal/agent/prompts/phase_cloud_configure_recording.md
@@ -50,6 +50,15 @@ Configure the recording parameters for Tusk Drift Cloud.
    - `export_spans`: the chosen value
    - `enable_env_var_recording`: the chosen value
 
+### Update .gitignore for Cloud
+
+After saving the cloud configuration, update `.gitignore` to also exclude `.tusk/traces`:
+
+1. Read `.gitignore` to check if `.tusk/traces` is already present
+2. If not present, append `.tusk/traces` to the Tusk section
+
+Since cloud users fetch traces from Tusk Cloud rather than storing them locally, the traces directory should be gitignored.
+
 ### Important Notes
 
 - Lower sampling rates reduce performance overhead

--- a/internal/agent/prompts/phase_create_config.md
+++ b/internal/agent/prompts/phase_create_config.md
@@ -77,6 +77,24 @@ Common config mistakes to avoid:
 - `readiness_command: "..."` should be `readiness_check: { command: "..." }` (nested structure)
 - `port: 3000` at root level should be `service: { port: 3000 }` (under service section)
 
+### Update .gitignore
+
+After creating the config file, update the project's `.gitignore` to exclude Tusk artifacts that shouldn't be committed:
+
+1. Use `read_file` to check if `.gitignore` exists and read its contents
+2. Check if Tusk entries (`.tusk/results`, `.tusk/logs`) are already present
+3. If missing, append the following block to `.gitignore`:
+
+```text
+# Tusk Drift
+.tusk/results
+.tusk/logs
+```
+
+- If `.gitignore` doesn't exist, create it with just the Tusk entries
+- If it exists but is missing entries, append to the end (ensure there's a blank line before the new section)
+- Do NOT add entries that already exist
+
 When done, call transition_phase with:
 {
   "results": {


### PR DESCRIPTION
### Summary

The setup agent now automatically updates `.gitignore` to exclude Tusk artifacts, automating what the README already recommends users do manually.

Resolves #129.

### Changes

- Add `.gitignore` update instructions to the Create Config phase, adding `.tusk/results` and `.tusk/logs`
- Add `.gitignore` update instructions to the Cloud Configure Recording phase, additionally adding `.tusk/traces` (since cloud users fetch traces remotely rather than storing locally)
- Add `read_file` and `write_file` tools to the cloud configure recording phase to enable gitignore updates
