### PR TITLE
refactor: omit `tusk_api.url` from generated configs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -203,7 +203,7 @@ See: [Docker Compose example](#starting-your-service-with-docker-compose).
       <td></td>
       <td>Cloud: yes</td>
       <td><code>TUSK_API_URL</code></td>
-      <td>Base URL of Tusk Drift Cloud (e.g., <code>https://api.usetusk.ai</code>). The CLI targets <code>/api/drift/test_run_service</code> under this host.</td>
+      <td>Base URL of Tusk Drift Cloud. The CLI targets <code>/api/drift/test_run_service</code> under this host. This defaults to <code>https://api.usetusk.ai</code>. You generally don't need to override this.</td>
     </tr>
   </tbody>
 </table>
@@ -470,9 +470,6 @@ service:
     command: curl -sf http://localhost:3000/health
     timeout: 30s
     interval: 2s
-
-tusk_api:
-  url: https://app.usetusk.ai
 ```
 
 To run against traces to Tusk Drift Cloud, your config file must contain `service.id` and `tusk_api.url`.

--- a/internal/agent/prompts/phase_create_config.md
+++ b/internal/agent/prompts/phase_create_config.md
@@ -18,9 +18,6 @@ service:
 traces:
   dir: .tusk/traces
 
-tusk_api:
-  url: https://api.usetusk.ai
-
 test_execution:
   timeout: 30s
 
@@ -50,9 +47,6 @@ service:
 
 traces:
   dir: .tusk/traces
-
-tusk_api:
-  url: https://api.usetusk.ai
 
 test_execution:
   timeout: 30s

--- a/internal/agent/tools/cloud.go
+++ b/internal/agent/tools/cloud.go
@@ -762,12 +762,6 @@ func (ct *CloudTools) SaveCloudConfig(input json.RawMessage) (string, error) {
 		"enable_env_var_recording": params.EnableEnvVarRecording,
 	}
 
-	if _, hasTuskAPI := config["tusk_api"]; !hasTuskAPI {
-		config["tusk_api"] = map[string]any{
-			"url": api.DefaultBaseURL,
-		}
-	}
-
 	output, err := yaml.Marshal(config)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal config: %w", err)

--- a/internal/api/cloud.go
+++ b/internal/api/cloud.go
@@ -14,9 +14,6 @@ func SetupCloud(ctx context.Context, requireServiceID bool) (*TuskClient, AuthOp
 	if cfgErr != nil {
 		return nil, AuthOptions{}, nil, fmt.Errorf("failed to load config: %w", cfgErr)
 	}
-	if cfg.TuskAPI.URL == "" {
-		return nil, AuthOptions{}, nil, fmt.Errorf("Tusk API URL is required. Set tusk_api.url in '.tusk/config.yaml' or run 'tusk init-cloud'")
-	}
 	if requireServiceID && cfg.Service.ID == "" {
 		return nil, AuthOptions{}, nil, fmt.Errorf("Service ID is required. Set config.service.id in '.tusk/config.yaml'")
 	}

--- a/internal/tui/onboard-cloud/run.go
+++ b/internal/tui/onboard-cloud/run.go
@@ -9,17 +9,11 @@ import (
 	"github.com/Use-Tusk/tusk-drift-cli/internal/api"
 	"github.com/Use-Tusk/tusk-drift-cli/internal/auth"
 	"github.com/Use-Tusk/tusk-drift-cli/internal/cliconfig"
-	"github.com/Use-Tusk/tusk-drift-cli/internal/config"
 	backend "github.com/Use-Tusk/tusk-drift-schemas/generated/go/backend"
 	tea "github.com/charmbracelet/bubbletea"
 )
 
 func Run() error {
-	// Ensure tusk_api.url is set in config before proceeding
-	if err := ensureTuskAPIURL(); err != nil {
-		return err
-	}
-
 	authenticator, err := ensureAuthenticated()
 	if err != nil {
 		return err
@@ -122,27 +116,6 @@ func fetchUserClients(m *Model, authenticator *auth.Authenticator) error {
 				}
 			}
 		}
-	}
-
-	return nil
-}
-
-// ensureTuskAPIURL checks if tusk_api.url is set in config, and adds it if missing
-func ensureTuskAPIURL() error {
-	cfg, err := config.Get()
-	if err != nil {
-		return fmt.Errorf("failed to load config: %w", err)
-	}
-
-	// If URL is already set, nothing to do
-	if cfg.TuskAPI.URL != "" {
-		return nil
-	}
-
-	// Add the default URL to config
-	slog.Debug("Adding tusk_api.url to config", "url", api.DefaultBaseURL)
-	if err := saveTuskAPIURLToConfig(api.DefaultBaseURL); err != nil {
-		return fmt.Errorf("failed to save tusk_api.url to config: %w", err)
 	}
 
 	return nil

--- a/internal/tui/onboard-cloud/save.go
+++ b/internal/tui/onboard-cloud/save.go
@@ -219,11 +219,3 @@ func saveRecordingConfig(samplingRate float64, exportSpans, enableEnvVarRecordin
 		return nil
 	})
 }
-
-func saveTuskAPIURLToConfig(url string) error {
-	return saveToConfig(func(cfg *config.Config, u *ConfigUpdater) error {
-		cfg.TuskAPI.URL = url
-		u.Set([]string{"tusk_api", "url"}, url)
-		return nil
-	})
-}

--- a/internal/tui/onboard-cloud/save_test.go
+++ b/internal/tui/onboard-cloud/save_test.go
@@ -70,10 +70,10 @@ func TestUpdateField_CreatesNestedStructure(t *testing.T) {
 	input := `service:
   name: my-service`
 
-	result := updateYAMLString(t, input, []string{"tusk_api", "url"}, "https://api.example.com")
+	result := updateYAMLString(t, input, []string{"custom_section", "custom_key"}, "custom_value")
 
-	assert.Contains(t, result, "tusk_api:")
-	assert.Contains(t, result, "url: https://api.example.com")
+	assert.Contains(t, result, "custom_section:")
+	assert.Contains(t, result, "custom_key: custom_value")
 }
 
 func TestUpdateField_PreservesComments(t *testing.T) {
@@ -176,45 +176,6 @@ recording:
 	assert.Contains(t, result, "enable_env_var_recording: true")
 	assert.NotContains(t, result, "!!float")
 	assert.NotContains(t, result, "!!bool")
-}
-
-func TestSaveTuskAPIURLToConfig_Integration(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "tusk-test-*")
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		_ = os.RemoveAll(tmpDir)
-		config.Invalidate()
-	})
-
-	originalWd, err := os.Getwd()
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.Chdir(originalWd) })
-
-	err = os.Chdir(tmpDir)
-	require.NoError(t, err)
-
-	// Create .tusk directory and config file without tusk_api section
-	tuskDir := filepath.Join(tmpDir, ".tusk")
-	err = os.MkdirAll(tuskDir, 0o750)
-	require.NoError(t, err)
-
-	initialConfig := `service:
-  name: test-service
-`
-	err = os.WriteFile(filepath.Join(tuskDir, "config.yaml"), []byte(initialConfig), 0o600)
-	require.NoError(t, err)
-
-	// Save tusk_api.url
-	err = saveTuskAPIURLToConfig("https://api.usetusk.ai")
-	require.NoError(t, err)
-
-	// Read the file back
-	data, err := os.ReadFile(filepath.Join(tuskDir, "config.yaml")) // #nosec G304
-	require.NoError(t, err)
-
-	result := string(data)
-	assert.Contains(t, result, "tusk_api:")
-	assert.Contains(t, result, "url: https://api.usetusk.ai")
 }
 
 // Helper function to test updateField without file I/O

--- a/internal/tui/onboard/config.go
+++ b/internal/tui/onboard/config.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/Use-Tusk/tusk-drift-cli/internal/api"
 	"github.com/Use-Tusk/tusk-drift-cli/internal/log"
 	"github.com/Use-Tusk/tusk-drift-cli/internal/tui/styles"
 	"gopkg.in/yaml.v3"
@@ -102,9 +101,6 @@ func (m *Model) getCurrentConfig() Config {
 		},
 		Traces: Traces{
 			Dir: ".tusk/traces",
-		},
-		TuskAPI: &TuskAPI{
-			URL: api.DefaultBaseURL,
 		},
 		TestExecution: TestExecution{
 			Timeout: "30s",


### PR DESCRIPTION
### Summary

Remove `tusk_api.url` from configs generated by `tusk init` and `tusk setup`. Since this field has a programmatic default (`https://api.usetusk.ai`) applied during config parsing, including it in generated configs is redundant and adds noise for users who rarely need to override it.

Resolves #123.

### Changes

- Remove `tusk_api` section from `tusk init` wizard config generation
- Remove `tusk_api` section from `tusk setup` agent prompt templates
- Remove code that adds `tusk_api` when saving cloud config
- Remove dead code checks for empty `tusk_api.url` (the default is always applied)
- Remove orphaned `ensureTuskAPIURL()` and `saveTuskAPIURLToConfig()` functions
- Update docs to clarify the default is applied automatically
