### PR TITLE
fix: no-op instead of error when CI user lacks Tusk Cloud seat

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -231,6 +231,11 @@ func runTests(cmd *cobra.Command, args []string) error {
 
 			id, err := client.CreateDriftRun(context.Background(), req, authOptions)
 			if err != nil {
+				// Handle NO_SEAT error as a no-op in CI mode
+				if api.IsNoSeatError(err) && ci {
+					log.Stderrln("Skipping: " + err.Error())
+					return nil
+				}
 				// TODO: make this more user-friendly, this is probably a server side issue, but could be wrong url set.
 				return fmt.Errorf("failed to create drift run: %w", err)
 			}


### PR DESCRIPTION
### Summary

When running in CI mode, if the PR creator doesn't have a Tusk Cloud seat, the CLI now exits gracefully with a skip message instead of failing with an error. This prevents CI pipelines from showing failures for users who simply aren't configured with seats.

Fixes #137

### Changes

- Added `NoSeatError` type in `internal/api/client.go` to identify seat-related errors
- Added `IsNoSeatError()` helper function to check for this error type
- Updated `CreateDriftRun` to return `NoSeatError` when backend returns `NO_SEAT` error code
- In `cmd/run.go`, handle `NO_SEAT` error as a no-op in CI mode: prints "Skipping: {message}" and exits with success (exit code 0)
