### PR TITLE
fix: show correct phases in intro screen for --skip-to-cloud mode

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -195,7 +195,7 @@ func (a *Agent) Run(parentCtx context.Context) error {
 
 	// Show intro screen and wait for user to continue
 	isProxyMode := a.client.mode == APIModeProxy
-	shouldContinue, err := a.ui.ShowIntro(isProxyMode)
+	shouldContinue, err := a.ui.ShowIntro(isProxyMode, a.skipToCloud)
 	if err != nil {
 		return fmt.Errorf("failed to show intro: %w", err)
 	}

--- a/internal/agent/ui.go
+++ b/internal/agent/ui.go
@@ -12,7 +12,8 @@ type AgentUI interface {
 	// ShowIntro displays the intro screen with animation and description.
 	// Returns true if user wants to continue, false if they quit.
 	// isProxyMode determines whether to show the proxy mode note.
-	ShowIntro(isProxyMode bool) (bool, error)
+	// skipToCloud determines whether to show the cloud-only phases description.
+	ShowIntro(isProxyMode, skipToCloud bool) (bool, error)
 
 	// Phase updates
 	PhaseChange(name, desc string, phaseNum, totalPhases int)

--- a/internal/agent/ui_headless.go
+++ b/internal/agent/ui_headless.go
@@ -59,8 +59,8 @@ func (u *HeadlessUI) Start() error {
 }
 
 // ShowIntro displays the intro screen for headless mode (no confirmation for scripts)
-func (u *HeadlessUI) ShowIntro(isProxyMode bool) (bool, error) {
-	PrintIntroHeadless(isProxyMode)
+func (u *HeadlessUI) ShowIntro(isProxyMode, skipToCloud bool) (bool, error) {
+	PrintIntroHeadless(isProxyMode, skipToCloud)
 	return true, nil
 }
 

--- a/internal/agent/ui_tui.go
+++ b/internal/agent/ui_tui.go
@@ -31,8 +31,8 @@ func (u *TUIUI) Start() error {
 }
 
 // ShowIntro displays the intro screen with animation
-func (u *TUIUI) ShowIntro(isProxyMode bool) (bool, error) {
-	return RunIntroScreen(isProxyMode)
+func (u *TUIUI) ShowIntro(isProxyMode, skipToCloud bool) (bool, error) {
+	return RunIntroScreen(isProxyMode, skipToCloud)
 }
 
 // Stop is a no-op for TUI - cleanup happens via the program


### PR DESCRIPTION
### Summary

The setup agent intro screen was showing the local setup phases even when users ran `tusk setup --skip-to-cloud`. This was misleading since the cloud-only flow uses entirely different phases.

### Changes

- Added `introDescriptionCloudOnly` constant with cloud-specific phases: Auth, Repository, Service, API Key, Recording, Upload, Validation
- Updated `getIntroDescription()` to accept `skipToCloud` parameter and return the appropriate description
- Extended `ShowIntro()` interface and implementations to pass through the `skipToCloud` flag
- Updated `IntroModel` to track `skipToCloud` mode for rendering the correct description

<img width="910" height="911" alt="image" src="https://github.com/user-attachments/assets/a944d7a8-708b-451e-80e3-973ba2b499c1" />

