### PR TITLE
feat: improve cloud setup prompts with clearer next steps

### DIFF
--- a/internal/agent/prompts/phase_cloud_create_api_key.md
+++ b/internal/agent/prompts/phase_cloud_create_api_key.md
@@ -1,6 +1,6 @@
 ## Phase: Create API Key
 
-Create an API key for recording traces to Tusk Cloud. This key authenticates your service with Tusk Cloud so recorded traces can be uploaded. This phase is optional - the user can skip if they already have an API key configured.
+Create an API key for recording traces to Tusk Cloud and CI/CD authentication. This key authenticates your service with Tusk Cloud so recorded traces can be uploaded. This phase is optional - the user can skip if they already have an API key configured.
 
 ### Steps
 

--- a/internal/agent/prompts/phase_cloud_summary.md
+++ b/internal/agent/prompts/phase_cloud_summary.md
@@ -56,8 +56,11 @@ Generate a final report documenting the cloud setup and list of next steps.
    - Or check the Tusk dashboard: https://app.usetusk.ai
 
    **Step 5: Set up a CI workflow**
-   Add Tusk Drift to your CI pipeline to automatically run tests on every PR:
-   - Docs: https://docs.usetusk.ai/api-tests/ci-cd-setup
+   Add Tusk Drift to your CI pipeline to automatically run tests on every PR. Note to the user that they can use same API key as above or create a new one:
+   - Docs:
+     - https://docs.usetusk.ai/api-tests/ci-cd-setup
+     - https://docs.usetusk.ai/api-tests/tusk-drift-cloud#deviation-analysis
+   
 
    **Step 6: Commit, merge & deploy**
    - Commit the SDK instrumentation changes and `.tusk/` config files


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation/prompt text changes only; no runtime logic, auth flow, or data handling code is modified.
> 
> **Overview**
> Updates the cloud setup agent prompts to clarify that the API key is used for *trace recording/uploads to Tusk Cloud* (in addition to CI/CD) and improves the user-facing question when creating a key.
> 
> Expands the Cloud Summary report to include a clearly displayed, numbered **Next Steps** checklist (update `TuskDrift.initialize()` with the API key, set env vars, deploy to a non-prod recording environment, verify trace uploads, set up CI, and commit/merge/deploy) and refreshes/extends useful links, including pointing users to `.tusk/CLOUD_SETUP_REPORT.md` for later reference.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c2c667ebbd1572cef35d21e27b2c859d5540aa3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->