### PR TITLE
feat: handle PAUSED_BY_LABEL error from backend

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -236,6 +236,11 @@ func runTests(cmd *cobra.Command, args []string) error {
 					log.Stderrln("Skipping: " + err.Error())
 					return nil
 				}
+				// Handle PAUSED_BY_LABEL error as a no-op in CI mode
+				if api.IsPausedByLabelError(err) && ci {
+					log.Stderrln("Skipping: " + err.Error())
+					return nil
+				}
 				// TODO: make this more user-friendly, this is probably a server side issue, but could be wrong url set.
 				return fmt.Errorf("failed to create drift run: %w", err)
 			}


### PR DESCRIPTION
- Add `PausedByLabelError` type to handle the new `PAUSED_BY_LABEL` error code from the backend
- In CI mode, treat this error as a no-op (exit cleanly without running tests)
- Follows the existing `NoSeatError` pattern

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized error-handling change that only affects the `CreateDriftRun` failure path in CI mode; minimal risk outside of potentially skipping CI runs when the backend sends this code.
> 
> **Overview**
> When creating a cloud drift run, the CLI now recognizes backend `PAUSED_BY_LABEL` failures and **skips execution in CI mode** (prints a "Skipping" message and exits successfully), mirroring existing `NO_SEAT` behavior.
> 
> This introduces a typed `PausedByLabelError` in `internal/api/client.go` and maps the backend error code `PAUSED_BY_LABEL` to it during `CreateDriftRun`, with a helper `IsPausedByLabelError` for callers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba161115297faa98ee43a43d4ed45263d9b274fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->