### PR TITLE
fix: make psycopg query matching safer and parse snake_case match importance

### DIFF
--- a/internal/runner/mock_matcher_test.go
+++ b/internal/runner/mock_matcher_test.go
@@ -594,6 +594,56 @@ func TestFindBestMatchWithTracePriority_SimilarityScoring_PicksClosestMatch(t *t
 	assert.Contains(t, level.MatchDescription, "similarity:")
 }
 
+func TestFindBestMatchWithTracePriority_PgQuery_DoesNotUseSchemaFallback(t *testing.T) {
+	cfg, _ := config.Get()
+	server, err := NewServer("svc", &cfg.Service)
+	require.NoError(t, err)
+	mm := NewMockMatcher(server)
+
+	traceID := "trace-pg-no-schema-fallback"
+	pkg := "psycopg2"
+
+	// Generic SQL schema (high collision risk)
+	inputSchema := &core.JsonSchema{
+		Properties: map[string]*core.JsonSchema{
+			"query":      {},
+			"parameters": {},
+		},
+	}
+
+	// Two recorded spans with same schema, different queries
+	span1 := makeSpan(
+		t,
+		traceID,
+		"span-1",
+		pkg,
+		map[string]any{"query": "SELECT 1", "parameters": []any{}},
+		inputSchema,
+		1000,
+	)
+	span2 := makeSpan(
+		t,
+		traceID,
+		"span-2",
+		pkg,
+		map[string]any{"query": "SELECT 2", "parameters": []any{}},
+		inputSchema,
+		2000,
+	)
+
+	server.LoadSpansForTrace(traceID, []*core.Span{span1, span2})
+
+	// Request that doesn't match either span by value hash, but shares the schema.
+	req := makeMockRequest(t, pkg, map[string]any{"query": "SELECT 3", "parameters": []any{}}, inputSchema)
+	req.OutboundSpan.SubmoduleName = "query"
+	req.OutboundSpan.Name = "psycopg2.query"
+	req.OutboundSpan.IsPreAppStart = false
+
+	match, _, err := mm.FindBestMatchWithTracePriority(req, traceID)
+	require.Error(t, err)
+	assert.Nil(t, match)
+}
+
 // TestFindBestMatchWithTracePriority_SimilarityScoring_TiebreakByTimestamp tests that when similarity
 // scores are identical, the oldest span is picked
 func TestFindBestMatchWithTracePriority_SimilarityScoring_TiebreakByTimestamp(t *testing.T) {


### PR DESCRIPTION
### Summary

Improve replay stability for Postgres spans by (1) correctly honoring `match_importance` emitted in trace JSONLs (Python SDK uses snake_case), and (2) preventing unsafe schema-based similarity fallback for `psycopg2.query`/`psycopg.query` spans, which can otherwise return incorrect DB mocks and cause confusing 500s.

### Changes

- Parse schema match importance from trace JSONLs:
  - Accept both `matchImportance` (camelCase) and `match_importance` (snake_case) in JSON schema parsing.
  - Parse `submoduleName` (camelCase) with fallback to legacy `submodule_name`.
- Add a PG-specific guardrail in mock matching:
  - Skip schema-hash + similarity fallback matching (priorities 7–10) for non-pre-app-start `psycopg2.query`/`psycopg.query` spans.
  - Rely on exact/reduced input value hash matching only; if no match exists, fail as "no matching span found" rather than returning an incorrect DB response.
- Tests:
  - Add a unit test ensuring `psycopg2` query spans do not use schema fallback matching.

### Notes / Compatibility

- Backwards compatible with existing recordings/SDKs: the parser now supports both schema key spellings.
- The matching guardrail only affects `psycopg2` and `psycopg` query spans; HTTP/Redis/Node SDK behavior is unchanged.