### PR TITLE
fix(makefile): use GOTOOLCHAIN=local for lint tool installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,8 @@ install-buf:
 
 install-lint-tools:
 	@echo "📦 Installing linting tools..."
-	go install mvdan.cc/gofumpt@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	GOTOOLCHAIN=local go install mvdan.cc/gofumpt@latest
+	GOTOOLCHAIN=local go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	@echo "✅ Linting tools installed"
 
 setup: install-buf deps install-lint-tools


### PR DESCRIPTION
Fixes lint tool installation failing when the project's Go version is newer than what golangci-lint's go.mod specifies.

## Problem

When running `make install-lint-tools`, golangci-lint is built respecting its own go.mod (`go 1.24`). When you then run `make lint` on this repo (`go 1.25`), it fails with:

```
Error: can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
```

CI works because `golangci-lint-action` sets up Go 1.25 first, so the toolchain is already correct.

## Fix

Add `GOTOOLCHAIN=local` to force Go to use the locally installed version when building lint tools, ensuring version compatibility with the project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Makefile-only change that affects developer/CI tooling installation; minimal impact on runtime behavior.
> 
> **Overview**
> Updates the `Makefile` `install-lint-tools` target to install `gofumpt` and `golangci-lint` with `GOTOOLCHAIN=local`, forcing tool builds to use the locally installed Go toolchain.
> 
> This prevents version-mismatch failures when lint tools are built with an older Go version than the repo targets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f194386dfa133cc450960ea80ec1f85d505b588. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->