### PR TITLE
fix: prefer root span timestamp for pre-request time travel

### DIFF
--- a/internal/runner/executor.go
+++ b/internal/runner/executor.go
@@ -742,7 +742,7 @@ func GetFirstSpanTimestamp(spans []*core.Span) (float64, string) {
 
 		spanTimestamp := float64(span.Timestamp.Seconds) + float64(span.Timestamp.Nanos)/1e9
 
-		// Track server span separately as fallback
+		// Track server span
 		if span.IsRootSpan {
 			serverSpanTimestamp = spanTimestamp
 			continue


### PR DESCRIPTION
### Summary

Fix replay deviations caused by time-sensitive code (e.g., `django-cachalot` cache key generation using `timezone.now()`) running at the start of inbound request processing. The existing `SendSetTimeTravel` gRPC call was using the earliest *non-server* span timestamp, which meant the clock was set to the time of the first outbound call rather than the time the request was originally received. This caused cache keys to differ between record and replay.

The fix flips the priority in `GetFirstSpanTimestamp` to prefer the root/server span timestamp, falling back to the earliest non-server span only when no root span exists.

### Changes

- **`internal/runner/executor.go`**: Flip priority in `GetFirstSpanTimestamp` ‚Äî prefer root/server span timestamp over earliest non-server span for time travel. This ensures the SDK's clock is set to the recorded inbound request time *before* the replay HTTP request is sent, so all time-dependent logic from the very start of request handling uses the correct time.
