### PR TITLE
feat: auto-ignore JWT dynamic claims during response comparison

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -285,6 +285,12 @@ For authentication in cloud mode, either use:
       <td><code>true</code></td>
       <td>Ignore date formats (e.g., <code>YYYY-MM-DD</code>) when both sides are dates.</td>
     </tr>
+    <tr>
+      <td><code>comparison.ignore_jwt_fields</code></td>
+      <td>boolean</td>
+      <td><code>true</code></td>
+      <td>When both expected and actual values are JWT tokens, decode their payloads and compare claims individually (ignoring the <code>jti</code> claim and applying other dynamic field rules to each claim). This handles tokens that differ only in per‑issuance fields like <code>jti</code> and their resulting signature.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,6 +83,7 @@ type ComparisonConfig struct {
 	IgnoreUUIDs      *bool    `koanf:"ignore_uuids"`
 	IgnoreTimestamps *bool    `koanf:"ignore_timestamps"`
 	IgnoreDates      *bool    `koanf:"ignore_dates"`
+	IgnoreJWTFields  *bool    `koanf:"ignore_jwt_fields"`
 }
 
 type RecordingConfig struct {

--- a/internal/runner/comparison.go
+++ b/internal/runner/comparison.go
@@ -115,14 +115,16 @@ func (e *Executor) compareResponseBodies(expected, actual any, testID string) bo
 			"ignorePatterns", comp.IgnorePatterns,
 			"ignoreUUIDs", comp.IgnoreUUIDs,
 			"ignoreTimestamps", comp.IgnoreTimestamps,
-			"ignoreDates", comp.IgnoreDates)
+			"ignoreDates", comp.IgnoreDates,
+			"ignoreJWTFields", comp.IgnoreJWTFields)
 
 		// Check if any comparison config is specified
 		hasConfig := len(comp.IgnoreFields) > 0 ||
 			len(comp.IgnorePatterns) > 0 ||
 			comp.IgnoreUUIDs != nil ||
 			comp.IgnoreTimestamps != nil ||
-			comp.IgnoreDates != nil
+			comp.IgnoreDates != nil ||
+			comp.IgnoreJWTFields != nil
 
 		if hasConfig {
 			comparisonConfig = comp

--- a/internal/runner/dynamic_fields.go
+++ b/internal/runner/dynamic_fields.go
@@ -1,7 +1,10 @@
 package runner
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 
@@ -21,6 +24,18 @@ type DynamicFieldMatcher struct {
 	customPatterns []*regexp.Regexp
 	// Exact field names to ignore
 	ignoreFields map[string]bool
+	// Whether to decode and compare JWT tokens by payload
+	ignoreJWT bool
+}
+
+// jwtRegex matches the general JWT format: three base64url segments separated by dots.
+// JWT headers always start with "eyJ" (base64url for '{"'), which reduces false positives.
+var jwtRegex = regexp.MustCompile(`^eyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]*$`)
+
+// jwtDynamicClaims are JWT claims that are inherently dynamic per-issuance
+// and should be automatically ignored when comparing JWT payloads.
+var jwtDynamicClaims = map[string]bool{
+	"jti": true, // JWT ID - unique per token issuance
 }
 
 // NewDynamicFieldMatcher creates a new matcher with default patterns
@@ -30,6 +45,7 @@ func NewDynamicFieldMatcher() *DynamicFieldMatcher {
 		timestampRegex: regexp.MustCompile(`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{3})?Z?$`),
 		dateRegex:      regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$|^\d{2}\/\d{2}\/\d{4}$|^\d{2}-\d{2}-\d{4}$`),
 		ignoreFields:   make(map[string]bool),
+		ignoreJWT:      true,
 	}
 }
 
@@ -48,6 +64,10 @@ func NewDynamicFieldMatcherWithConfig(cfg *config.ComparisonConfig) *DynamicFiel
 		// Check if date ignoring is explicitly disabled
 		if cfg.IgnoreDates != nil && !*cfg.IgnoreDates {
 			matcher.dateRegex = nil
+		}
+		// Check if JWT ignoring is explicitly disabled
+		if cfg.IgnoreJWTFields != nil && !*cfg.IgnoreJWTFields {
+			matcher.ignoreJWT = false
 		}
 
 		// Add custom field names
@@ -109,6 +129,94 @@ func (m *DynamicFieldMatcher) ShouldIgnoreField(fieldName string, expectedValue,
 		}
 	}
 
+	// Check for JWT tokens - decode payloads and compare claims
+	if m.ignoreJWT && m.shouldIgnoreJWT(expectedStr, actualStr, testID, fieldName) {
+		return true
+	}
+
 	log.Debug("Field NOT ignored", "field", fieldName, "expected", expectedValue, "actual", actualValue)
 	return false
+}
+
+// shouldIgnoreJWT checks if both values are JWT tokens whose payloads match
+// after ignoring known dynamic claims (like jti) and applying pattern matching.
+// JWT signatures are derived from the payload content + secret, so they are
+// expected to differ when any claim differs - we only compare payloads.
+func (m *DynamicFieldMatcher) shouldIgnoreJWT(expectedStr, actualStr, testID, fieldName string) bool {
+	if !jwtRegex.MatchString(expectedStr) || !jwtRegex.MatchString(actualStr) {
+		return false
+	}
+
+	expectedPayload, err := decodeJWTPayload(expectedStr)
+	if err != nil {
+		log.Debug("Failed to decode expected JWT payload", "field", fieldName, "error", err)
+		return false
+	}
+	actualPayload, err := decodeJWTPayload(actualStr)
+	if err != nil {
+		log.Debug("Failed to decode actual JWT payload", "field", fieldName, "error", err)
+		return false
+	}
+
+	if len(expectedPayload) != len(actualPayload) {
+		log.Debug("JWT payload key count mismatch", "field", fieldName, "expected_keys", len(expectedPayload), "actual_keys", len(actualPayload))
+		return false
+	}
+
+	// Compare each claim in the expected payload
+	for key, expectedVal := range expectedPayload {
+		actualVal, exists := actualPayload[key]
+		if !exists {
+			return false
+		}
+
+		if reflect.DeepEqual(expectedVal, actualVal) {
+			continue
+		}
+
+		if jwtDynamicClaims[key] {
+			log.TestLog(testID, fmt.Sprintf("🔄 Ignoring JWT claim '%s' in field '%s' (known dynamic JWT claim): expected=%v, actual=%v", key, fieldName, expectedVal, actualVal))
+			continue
+		}
+
+		if m.ShouldIgnoreField(key, expectedVal, actualVal, testID) {
+			continue
+		}
+
+		log.Debug("JWT payload claim mismatch", "field", fieldName, "claim", key, "expected", expectedVal, "actual", actualVal)
+		return false
+	}
+
+	// Check for extra keys in actual payload
+	for key := range actualPayload {
+		if _, exists := expectedPayload[key]; !exists {
+			return false
+		}
+	}
+
+	log.TestLog(testID, fmt.Sprintf("🔄 Ignoring field '%s' (JWT tokens with matching payload after ignoring dynamic claims)", fieldName))
+	log.Debug("Field ignored by JWT payload comparison", "field", fieldName)
+	return true
+}
+
+// decodeJWTPayload decodes the payload (second segment) of a JWT token
+// and returns it as a map. Returns an error if the token is malformed.
+func decodeJWTPayload(token string) (map[string]any, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return nil, fmt.Errorf("invalid JWT format: expected 3 parts, got %d", len(parts))
+	}
+
+	// Decode the payload using base64url without padding (standard JWT encoding)
+	decoded, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("failed to base64url decode JWT payload: %w", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(decoded, &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse JWT payload as JSON: %w", err)
+	}
+
+	return payload, nil
 }

--- a/internal/runner/dynamic_fields_test.go
+++ b/internal/runner/dynamic_fields_test.go
@@ -314,3 +314,156 @@ func TestShouldIgnoreField_NonStringValues(t *testing.T) {
 		nil,
 		"test-1"))
 }
+
+func TestShouldIgnoreField_JWT_DefaultEnabled(t *testing.T) {
+	matcher := NewDynamicFieldMatcher()
+
+	// Both values are JWTs where only jti differs - should ignore
+	expectedJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcwMzE2Mzc3LCJpYXQiOjE3NzAzMDkxNzcsImp0aSI6IjE5MWY4Y2Y0NjIwNjRkNmY5ZWYzYTJhZDMxZTEwNDJlIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9.hO9f2F0-6ewAk7FaLCjEI9zTOxAB7N3xTvsmBHhcAe0"
+	actualJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcwMzE2Mzc3LCJpYXQiOjE3NzAzMDkxNzcsImp0aSI6IjYwOTY1YmQ2MTJhZjRkNTA5ZDc1Mjk0NDgxYTc2NDExIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9._cHYQ8YcVfqQpWsuNUd38JYCjKOWXNglGocaWAiuodY"
+
+	require.True(t, matcher.ShouldIgnoreField("access", expectedJWT, actualJWT, "test-jwt-1"))
+}
+
+func TestShouldIgnoreField_JWT_RefreshToken(t *testing.T) {
+	matcher := NewDynamicFieldMatcher()
+
+	// Refresh tokens where only jti differs
+	expectedJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTc3MDM5NTU3NywiaWF0IjoxNzcwMzA5MTc3LCJqdGkiOiIyZjQzODVhYzdmZDk0ZGM3ODlmYTQ1OWUxMWEzN2Q2MSIsInVzZXJfaWQiOiIwYzcwZjA3Yy1lMDNhLTQyODAtYjlkMC0xNmZhMTY4YTYyZDEifQ.GTExDgK_QZD0GHEbIVOZLdiHMQJdN-58Z12ML-q3LMI"
+	actualJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTc3MDM5NTU3NywiaWF0IjoxNzcwMzA5MTc3LCJqdGkiOiI0N2VkMDc2YmVhN2U0M2MxOGE0Mjk3MjY1OWU2OWU3NCIsInVzZXJfaWQiOiIwYzcwZjA3Yy1lMDNhLTQyODAtYjlkMC0xNmZhMTY4YTYyZDEifQ.iedWNUBUAxJXdFbJ6uYlAowQ28esXz9D3HHIkER_glg"
+
+	require.True(t, matcher.ShouldIgnoreField("refresh", expectedJWT, actualJWT, "test-jwt-2"))
+}
+
+func TestShouldIgnoreField_JWT_Disabled(t *testing.T) {
+	falseValue := false
+	cfg := &config.ComparisonConfig{
+		IgnoreJWTFields: &falseValue,
+	}
+	matcher := NewDynamicFieldMatcherWithConfig(cfg)
+
+	// Even with valid JWTs, should not ignore when disabled
+	expectedJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcwMzE2Mzc3LCJpYXQiOjE3NzAzMDkxNzcsImp0aSI6IjE5MWY4Y2Y0NjIwNjRkNmY5ZWYzYTJhZDMxZTEwNDJlIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9.hO9f2F0-6ewAk7FaLCjEI9zTOxAB7N3xTvsmBHhcAe0"
+	actualJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcwMzE2Mzc3LCJpYXQiOjE3NzAzMDkxNzcsImp0aSI6IjYwOTY1YmQ2MTJhZjRkNTA5ZDc1Mjk0NDgxYTc2NDExIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9._cHYQ8YcVfqQpWsuNUd38JYCjKOWXNglGocaWAiuodY"
+
+	require.False(t, matcher.ShouldIgnoreField("access", expectedJWT, actualJWT, "test-jwt-3"))
+}
+
+func TestShouldIgnoreField_JWT_ExplicitlyEnabled(t *testing.T) {
+	trueValue := true
+	cfg := &config.ComparisonConfig{
+		IgnoreJWTFields: &trueValue,
+	}
+	matcher := NewDynamicFieldMatcherWithConfig(cfg)
+
+	expectedJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcwMzE2Mzc3LCJpYXQiOjE3NzAzMDkxNzcsImp0aSI6IjE5MWY4Y2Y0NjIwNjRkNmY5ZWYzYTJhZDMxZTEwNDJlIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9.hO9f2F0-6ewAk7FaLCjEI9zTOxAB7N3xTvsmBHhcAe0"
+	actualJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcwMzE2Mzc3LCJpYXQiOjE3NzAzMDkxNzcsImp0aSI6IjYwOTY1YmQ2MTJhZjRkNTA5ZDc1Mjk0NDgxYTc2NDExIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9._cHYQ8YcVfqQpWsuNUd38JYCjKOWXNglGocaWAiuodY"
+
+	require.True(t, matcher.ShouldIgnoreField("access", expectedJWT, actualJWT, "test-jwt-4"))
+}
+
+func TestShouldIgnoreField_JWT_PayloadClaimDiffers(t *testing.T) {
+	matcher := NewDynamicFieldMatcher()
+
+	// JWTs where a non-dynamic claim (token_type) differs - should not ignore
+	// Expected: token_type=access, Actual: token_type=refresh
+	expectedJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcwMzE2Mzc3LCJpYXQiOjE3NzAzMDkxNzcsImp0aSI6IjE5MWY4Y2Y0NjIwNjRkNmY5ZWYzYTJhZDMxZTEwNDJlIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9.hO9f2F0-6ewAk7FaLCjEI9zTOxAB7N3xTvsmBHhcAe0"
+	actualJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoicmVmcmVzaCIsImV4cCI6MTc3MDM5NTU3NywiaWF0IjoxNzcwMzA5MTc3LCJqdGkiOiI0N2VkMDc2YmVhN2U0M2MxOGE0Mjk3MjY1OWU2OWU3NCIsInVzZXJfaWQiOiIwYzcwZjA3Yy1lMDNhLTQyODAtYjlkMC0xNmZhMTY4YTYyZDEifQ.iedWNUBUAxJXdFbJ6uYlAowQ28esXz9D3HHIkER_glg"
+
+	require.False(t, matcher.ShouldIgnoreField("token", expectedJWT, actualJWT, "test-jwt-5"))
+}
+
+func TestShouldIgnoreField_JWT_NotAJWT(t *testing.T) {
+	matcher := NewDynamicFieldMatcher()
+
+	// Values that look like they could have dots but are not JWTs
+	require.False(t, matcher.ShouldIgnoreField("field",
+		"not.a.jwt",
+		"also.not.jwt",
+		"test-jwt-6"))
+
+	// One is JWT, other is not
+	validJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcwMzE2Mzc3LCJpYXQiOjE3NzAzMDkxNzcsImp0aSI6IjE5MWY4Y2Y0NjIwNjRkNmY5ZWYzYTJhZDMxZTEwNDJlIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9.hO9f2F0-6ewAk7FaLCjEI9zTOxAB7N3xTvsmBHhcAe0"
+	require.False(t, matcher.ShouldIgnoreField("field",
+		validJWT,
+		"not-a-jwt",
+		"test-jwt-6"))
+}
+
+func TestShouldIgnoreField_JWT_IdenticalTokens(t *testing.T) {
+	matcher := NewDynamicFieldMatcher()
+
+	// Identical JWT strings - should be caught by the equality check before JWT logic
+	jwt := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcwMzE2Mzc3LCJpYXQiOjE3NzAzMDkxNzcsImp0aSI6IjE5MWY4Y2Y0NjIwNjRkNmY5ZWYzYTJhZDMxZTEwNDJlIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9.hO9f2F0-6ewAk7FaLCjEI9zTOxAB7N3xTvsmBHhcAe0"
+
+	// This actually passes via the equality check in compareJSONValues before
+	// ShouldIgnoreField is even called, but verify the matcher also handles it
+	require.True(t, matcher.ShouldIgnoreField("access", jwt, jwt, "test-jwt-7"))
+}
+
+func TestShouldIgnoreField_JWT_WithUUIDClaimDifference(t *testing.T) {
+	matcher := NewDynamicFieldMatcher()
+
+	// JWTs where user_id (a UUID with dashes) differs - UUID ignoring should handle it
+	// Expected user_id: 0c70f07c-e03a-4280-b9d0-16fa168a62d1
+	expectedJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwianRpIjoiYWJjMTIzIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9.sig1"
+	// Actual user_id: 11111111-1111-1111-1111-111111111111
+	actualJWT := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwianRpIjoiZGVmNDU2IiwidXNlcl9pZCI6IjExMTExMTExLTExMTEtMTExMS0xMTExLTExMTExMTExMTExMSJ9.sig2"
+
+	require.True(t, matcher.ShouldIgnoreField("access", expectedJWT, actualJWT, "test-jwt-8"))
+}
+
+func TestDecodeJWTPayload(t *testing.T) {
+	// Valid JWT with known payload
+	token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNzcwMzE2Mzc3LCJpYXQiOjE3NzAzMDkxNzcsImp0aSI6IjE5MWY4Y2Y0NjIwNjRkNmY5ZWYzYTJhZDMxZTEwNDJlIiwidXNlcl9pZCI6IjBjNzBmMDdjLWUwM2EtNDI4MC1iOWQwLTE2ZmExNjhhNjJkMSJ9.hO9f2F0-6ewAk7FaLCjEI9zTOxAB7N3xTvsmBHhcAe0" //nolint:gosec
+
+	payload, err := decodeJWTPayload(token)
+	require.NoError(t, err)
+	require.Equal(t, "access", payload["token_type"])
+	require.Equal(t, float64(1770316377), payload["exp"])
+	require.Equal(t, float64(1770309177), payload["iat"])
+	require.Equal(t, "191f8cf462064d6f9ef3a2ad31e1042e", payload["jti"])
+	require.Equal(t, "0c70f07c-e03a-4280-b9d0-16fa168a62d1", payload["user_id"])
+}
+
+func TestDecodeJWTPayload_InvalidFormat(t *testing.T) {
+	// Not a JWT - no dots
+	_, err := decodeJWTPayload("not-a-jwt")
+	require.Error(t, err)
+
+	// Only two segments
+	_, err = decodeJWTPayload("abc.def")
+	require.Error(t, err)
+
+	// Invalid base64 in payload
+	_, err = decodeJWTPayload("eyJhbGciOiJIUzI1NiJ9.!!!invalid!!!.sig")
+	require.Error(t, err)
+
+	// Valid base64 but not JSON
+	_, err = decodeJWTPayload("eyJhbGciOiJIUzI1NiJ9.bm90LWpzb24.sig")
+	require.Error(t, err)
+}
+
+func TestNewDynamicFieldMatcherWithConfig_JWTDefault(t *testing.T) {
+	// Default (nil config) should have JWT ignoring enabled
+	matcher := NewDynamicFieldMatcherWithConfig(nil)
+	require.True(t, matcher.ignoreJWT)
+}
+
+func TestNewDynamicFieldMatcherWithConfig_JWTDisabled(t *testing.T) {
+	falseValue := false
+	cfg := &config.ComparisonConfig{
+		IgnoreJWTFields: &falseValue,
+	}
+	matcher := NewDynamicFieldMatcherWithConfig(cfg)
+	require.False(t, matcher.ignoreJWT)
+}
+
+func TestNewDynamicFieldMatcherWithConfig_JWTEnabled(t *testing.T) {
+	trueValue := true
+	cfg := &config.ComparisonConfig{
+		IgnoreJWTFields: &trueValue,
+	}
+	matcher := NewDynamicFieldMatcherWithConfig(cfg)
+	require.True(t, matcher.ignoreJWT)
+}


### PR DESCRIPTION
### Summary

Adds automatic JWT-aware comparison to the dynamic field matcher. When response bodies contain JWT tokens, the runner now decodes their payloads and compares claims individually, automatically ignoring known per-issuance dynamic claims like `jti`. This prevents false test failures for APIs that return JWTs (e.g. login/token-refresh endpoints). The feature is enabled by default and can be disabled via `ignore_jwt_fields: false` in comparison config.

### Changes

- Add JWT payload decoding and claim-by-claim comparison in `dynamic_fields.go`, with known dynamic claims (`jti`) auto-ignored and other differing claims delegated to existing pattern matchers (e.g. UUID ignoring handles `user_id` differences)
- Add `IgnoreJWTFields` option to `ComparisonConfig` (default: enabled) and wire it through comparison logic
- Add unit tests for JWT matching (enabled/disabled, payload mismatches, non-JWT values, identical tokens, nested UUID claim differences) and integration tests at the `compareAndGenerateResult` level
