### PR TITLE
fix: preserve UTF-8 encoding when copying to clipboard on macOS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Use-Tusk/fence v0.1.16
 	github.com/Use-Tusk/tusk-drift-schemas v0.1.30
 	github.com/agnivade/levenshtein v1.0.3
-	github.com/atotto/clipboard v0.1.4
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7
 	github.com/charmbracelet/bubbletea v1.3.9
@@ -34,6 +33,7 @@ require (
 
 require (
 	github.com/alecthomas/chroma/v2 v2.14.0 // indirect
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.9.1 // indirect
 	github.com/catppuccin/go v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,16 +2,6 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Use-Tusk/fence v0.1.16 h1:iTHn7ttCbvUANZ9Bo/3HyZYAw7ZrNAjoZjaX7kDbE0I=
 github.com/Use-Tusk/fence v0.1.16/go.mod h1:topOkP7EULI+78u+Ax775d36GqWfx2BhqkVEQ/QXXAU=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.24 h1:q5rdVm46qk+6s7THk1QeSYDJc+/nL63ChyEYF/VxaTM=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.24/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.25-0.20260127032119-ba5c9c37743f h1:fgrFZDrRqSPfVtBg0FPT5W4KUmXDTL9eO3cG0OnGC0s=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.25-0.20260127032119-ba5c9c37743f/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.27 h1:AEQjJwXUEs3cu427/GSF05GnutFak7iVEdn8mknPmTw=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.27/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.28 h1:S+sGmSdhwxWYXo/761Fn6Tey7HN7Zp4TTvVSPwJDf24=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.28/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.29 h1:wlVHhIa85jSlSVWGiRlLIEYoIqSh7oLsLJRXH5lKJmM=
-github.com/Use-Tusk/tusk-drift-schemas v0.1.29/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
 github.com/Use-Tusk/tusk-drift-schemas v0.1.30 h1:A45pJ/Za6BLIfTLF53BhuzKHHSJ9L7dXEisnuKT5dTc=
 github.com/Use-Tusk/tusk-drift-schemas v0.1.30/go.mod h1:pa3EvTj9kKxl9f904RVFkj9YK1zB75QogboKi70zalM=
 github.com/agnivade/levenshtein v1.0.3 h1:M5ZnqLOoZR8ygVq0FfkXsNOKzMCk0xRiow0R5+5VkQ0=

--- a/internal/tui/components/content_panel.go
+++ b/internal/tui/components/content_panel.go
@@ -4,13 +4,13 @@ import (
 	"strings"
 	"time"
 
-	"github.com/atotto/clipboard"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/reflow/ansi"
 
 	"github.com/Use-Tusk/tusk-drift-cli/internal/tui/styles"
+	"github.com/Use-Tusk/tusk-drift-cli/internal/utils"
 )
 
 // SelectionPos represents a position in the content
@@ -627,7 +627,7 @@ func (cp *ContentPanel) copyToClipboard(text string) {
 		return
 	}
 
-	if err := clipboard.WriteAll(text); err == nil {
+	if err := utils.WriteToSystemClipboard(text); err == nil {
 		cp.showCopied = true
 	}
 }


### PR DESCRIPTION
### Summary

Clipboard copy (pressing "y" in the TUI) was garbling Unicode characters like emojis (üöÄ, ‚ö†, üí°) and box-drawing characters (‚ï≠, ‚îÄ, ‚ï∞, ‚îÇ) on macOS. The root cause is that `pbcopy` defaults to interpreting stdin as Mac OS Roman (based on `__CF_USER_TEXT_ENCODING`), so multi-byte UTF-8 sequences were being double-encoded into the wrong characters.

### Changes

- Replaced `atotto/clipboard` with a direct `pbcopy` call that explicitly sets `__CF_USER_TEXT_ENCODING` to UTF-8 (`0x08000100`), fixing the encoding issue on macOS
- Added `WriteToSystemClipboard()` utility in `internal/utils/misc.go` with platform-specific clipboard support (macOS via `pbcopy`, Linux via `xclip`/`xsel`)
- Updated `content_panel.go` to use the new centralized clipboard utility
- Removed direct dependency on `github.com/atotto/clipboard`
