### PR TITLE
feat: show text selection hint on mouse drag in TUI footer for setup agent

### DIFF
--- a/internal/agent/tui.go
+++ b/internal/agent/tui.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -1504,13 +1505,16 @@ func (m *TUIModel) renderFooter() string {
 	return components.Footer(m.width, m.applyDragHint(helpText))
 }
 
-// applyDragHint appends the "Hold Option to select text" hint to the right side of the footer text
+// applyDragHint appends a platform-appropriate text selection hint to the right side of the footer text
 func (m *TUIModel) applyDragHint(text string) string {
 	if !m.dragHintVisible {
 		return text
 	}
 
-	hint := "Hold Option to select text"
+	hint := "Hold Shift to select text"
+	if runtime.GOOS == "darwin" {
+		hint = "Hold Option to select text"
+	}
 	hintWidth := lipgloss.Width(hint)
 	textWidth := lipgloss.Width(text)
 	// Calculate padding to right-align hint flush to the right edge


### PR DESCRIPTION
### Summary

When users try to drag-select text in the TUI (which doesn't work natively in Bubble Tea's alternate screen), there's no indication of what went wrong or how to actually select text. This adds a contextual, platform-aware hint that appears in the footer when a mouse drag is detected, guiding users to hold the correct modifier key (Option on macOS, Shift on Linux/Windows).

### Context

Bubble Tea enables mouse event capture to support scrolling within the TUI viewport. However, when a terminal emulator's mouse reporting is active, the terminal forwards mouse events (including click-and-drag) to the application instead of handling them natively. This means native text selection via drag is intercepted by the TUI rather than processed by the terminal. On macOS, holding Option bypasses this and tells the terminal to handle the selection itself; on Linux/Windows, the equivalent modifier is typically Shift.

### Changes

- Mouse drag detection: Track `MouseButtonLeft` drag via `MouseActionMotion` / `MouseActionRelease` events to detect when the user attempts to select text.
- Platform-aware footer hint: Added `applyDragHint()` which right-aligns a hint in the footer bar ‚Äî "Hold Option to select text" on macOS, "Hold Shift to select text" on Linux/Windows (via `runtime.GOOS`). The hint appears on drag and auto-expires 10 seconds after mouse release.
- Footer rendering cleanup: Refactored `renderFooter()` so all code paths consistently apply the drag hint via `applyDragHint()` before passing text to `components.Footer()`. The `completed`, `shutdownRequested`, and `default` cases now share a single return path.
- Shutdown layout fix: Added `m.updateViewportSize()` to the `shutdownStartedMsg` handler to fix a bug where the footer shifted up by 1 line (leaving a blank line at the bottom) when pressing Ctrl+C during permission mode. The root cause was that exiting permission mode recalculated the viewport, but the subsequent shutdown transition did not.