### PR TITLE
refactor: update setup progress and report paths to .tusk/setup directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ We recommend adding to your `.gitignore`:
 
 - `.tusk/results`
 - `.tusk/logs`
+- `.tusk/setup`
 - `.tusk/traces` (if you primarily intend to use Tusk Drift Cloud)
 
 ## Resources

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -46,7 +46,7 @@ func init() {
 	setupCmd.Flags().StringVar(&setupModel, "model", "claude-sonnet-4-5-20250929", "Claude model to use")
 	setupCmd.Flags().BoolVar(&setupSkipPermissions, "skip-permissions", false, "Skip permission prompts for consequential actions (commands, file writes, etc.)")
 	setupCmd.Flags().BoolVar(&setupNoSkipPermissions, "no-skip-permissions", false, "In headless mode (--print), still prompt for permissions instead of auto-approving")
-	setupCmd.Flags().BoolVar(&setupDisableProgress, "disable-progress-state", false, "Disable progress state (saving to a PROGRESS.md file) or resuming from it")
+	setupCmd.Flags().BoolVar(&setupDisableProgress, "disable-progress-state", false, "Disable progress state (saving to .tusk/setup/PROGRESS.md) or resuming from it")
 	setupCmd.Flags().BoolVar(&setupSkipToCloud, "skip-to-cloud", false, "Skip local setup and go directly to cloud setup (for testing)")
 	setupCmd.Flags().BoolVar(&setupPrintMode, "print", false, "Headless mode - no TUI, stream output to stdout (auto-approves permissions unless --no-skip-permissions)")
 	setupCmd.Flags().BoolVar(&setupOutputLogs, "output-logs", false, "Output all logs (tool calls, messages) to .tusk/logs/setup-<datetime>.log")

--- a/cmd/short_docs/setup.md
+++ b/cmd/short_docs/setup.md
@@ -33,7 +33,7 @@ To use your own Anthropic API key instead:
 
 ## Progress & Resumption
 
-The agent saves progress to `PROGRESS.md` by default. If setup is interrupted, running `tusk setup` again will resume from where it left off. Use `--disable-progress-state` to start fresh.
+The agent saves progress to `.tusk/setup/PROGRESS.md` by default. If setup is interrupted, running `tusk setup` again will resume from where it left off. Use `--disable-progress-state` to start fresh.
 
 ## Cloud Setup
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,7 +7,7 @@ If `tusk setup` (AI-powered setup) fails or doesn't support your project:
 - **Missing API key**: The agent requires an Anthropic API key. Set it via `export ANTHROPIC_API_KEY=your-key` or pass `--api-key your-key`.
 - **Unsupported language/framework**: The AI agent currently supports Python (FastAPI, Flask, Django, Starlette) and Node.js (Express, Fastify, Koa, Hapi).
 - **Agent errors or timeouts**: Try running with `--print` for headless mode to see detailed output. You can also use `--output-logs` to save logs to `.tusk/logs/`.
-- **Resume interrupted setup**: The agent saves progress to `PROGRESS.md`. Run `tusk setup` again to resume, or use `--disable-progress-state` to start fresh.
+- **Resume interrupted setup**: The agent saves progress to `.tusk/setup/PROGRESS.md`. Run `tusk setup` again to resume, or use `--disable-progress-state` to start fresh.
 - **Fallback options**: If you prefer not to use the AI agent, you may also use `tusk init` for local setup and `tusk init-cloud` for cloud configuration.
 
 ## Connection Issues

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -25,7 +25,10 @@ import (
 	"github.com/Use-Tusk/tusk-drift-cli/internal/log"
 )
 
-const progressFileName = "PROGRESS.md"
+const (
+	progressFileName  = "PROGRESS.md"
+	setupArtifactsDir = "setup"
+)
 
 // Timeouts
 const (
@@ -45,7 +48,7 @@ const (
 
 // RecoveryGuidance returns a message explaining how to resume after a failure
 func RecoveryGuidance() string {
-	return `Progress has been saved to .tusk/PROGRESS.md
+	return `Progress has been saved to .tusk/setup/PROGRESS.md
 Run 'tusk setup' again to continue where you left off.
 
 If issues persist, contact support@usetusk.ai`
@@ -319,7 +322,7 @@ func (a *Agent) runAgent() error {
 					if rerun {
 						// Start fresh - delete progress and report files
 						a.deleteProgress()
-						_ = os.Remove(filepath.Join(a.workDir, ".tusk", "SETUP_REPORT.md"))
+						_ = os.Remove(filepath.Join(a.workDir, ".tusk", setupArtifactsDir, "SETUP_REPORT.md"))
 						completedPhases = nil
 						a.phaseManager = NewPhaseManager()
 						a.ui.AgentText("Starting fresh setup...\n", false)
@@ -1452,7 +1455,7 @@ func generateSessionID() string {
 // Progress file management
 
 func (a *Agent) progressFilePath() string {
-	return filepath.Join(a.workDir, ".tusk", progressFileName)
+	return filepath.Join(a.workDir, ".tusk", setupArtifactsDir, progressFileName)
 }
 
 // readProgress reads the existing progress file if it exists
@@ -1605,8 +1608,8 @@ func (a *Agent) saveProgress(completedPhases []string, currentPhase string, note
 		return nil
 	}
 
-	tuskDir := filepath.Join(a.workDir, ".tusk")
-	if err := os.MkdirAll(tuskDir, 0o750); err != nil {
+	setupDir := filepath.Join(a.workDir, ".tusk", setupArtifactsDir)
+	if err := os.MkdirAll(setupDir, 0o750); err != nil {
 		return err
 	}
 

--- a/internal/agent/prompts/phase_cloud_summary.md
+++ b/internal/agent/prompts/phase_cloud_summary.md
@@ -37,7 +37,7 @@ Generate a final report documenting the cloud setup and list of next steps.
    - Understand/find their `TuskDrift.initialize` call in their codebase
    - Once you find their existing initialization, show them how to modify their code to add the API key
    - Your example should match their existing code style, file location, and any other options they already have configured
-   - If the API key was not created (api_key_created == false), remind the user they'll need to create one at https://app.usetusk.ai/app/settings/api-keys before this will work.
+   - If the API key was not created (api_key_created == false), remind the user they'll need to create one at <https://app.usetusk.ai/app/settings/api-keys> before this will work.
 
    **Step 2: Store your environment variables**
    Set these environment variables wherever you want to record traces:
@@ -53,26 +53,25 @@ Generate a final report documenting the cloud setup and list of next steps.
    **Step 4: Verify traces are recording**
    After deploying, confirm traces are being uploaded:
    - Run `tusk list --cloud` to see cloud traces
-   - Or check the Tusk dashboard: https://app.usetusk.ai
+   - Or check the Tusk dashboard: <https://app.usetusk.ai>
 
    **Step 5: Set up a CI workflow**
    Add Tusk Drift to your CI pipeline to automatically run tests on every PR. Note to the user that they can use same API key as above or create a new one:
    - Docs:
-     - https://docs.usetusk.ai/api-tests/ci-cd-setup
-     - https://docs.usetusk.ai/api-tests/tusk-drift-cloud#deviation-analysis
-   
+     - <https://docs.usetusk.ai/api-tests/ci-cd-setup>
+     - <https://docs.usetusk.ai/api-tests/tusk-drift-cloud#deviation-analysis>
 
    **Step 6: Commit, merge & deploy**
    - Commit the SDK instrumentation changes and `.tusk/` config files
    - Open a PR/MR, merge, and deploy to your recording environment
 
 7. **Useful Links**:
-   - Dashboard: https://app.usetusk.ai
-   - Documentation: https://docs.usetusk.ai/api-tests/tusk-drift-cloud
-   - CI/CD Setup Guide: https://docs.usetusk.ai/api-tests/ci-cd-setup
-   - Support: support@usetusk.ai
+   - Dashboard: <https://app.usetusk.ai>
+   - Documentation: <https://docs.usetusk.ai/api-tests/tusk-drift-cloud>
+   - CI/CD Setup Guide: <https://docs.usetusk.ai/api-tests/ci-cd-setup>
+   - Support: <support@usetusk.ai>
 
-Mention that they can view this checklist at any time in `.tusk/CLOUD_SETUP_REPORT.md`.
+Mention that they can view this checklist at any time in `.tusk/setup/CLOUD_SETUP_REPORT.md`.
 
 ### Steps For Agent (You)
 
@@ -80,7 +79,7 @@ Mention that they can view this checklist at any time in `.tusk/CLOUD_SETUP_REPO
 
 2. **Display report**: Output the full report content to the terminal so the user can read it. The Next Steps checklist (section 6) is especially important — make sure it is clearly displayed.
 
-3. **Save report**: Use `write_file` to save the report to `.tusk/CLOUD_SETUP_REPORT.md`
+3. **Save report**: Use `write_file` to save the report to `.tusk/setup/CLOUD_SETUP_REPORT.md`
 
 4. **Transition**: Call `transition_phase` to complete the setup.
 

--- a/internal/agent/prompts/phase_complex_test.md
+++ b/internal/agent/prompts/phase_complex_test.md
@@ -29,11 +29,11 @@ This phase is optional - if you can't test a complex endpoint, that's okay.
 
 ### Step 3: Save to Verify Cache
 
-If the test passed, save the endpoint info used to `.tusk/verify-cache.json` so that
+If the test passed, save the endpoint info used to `.tusk/setup/verify-cache.json` so that
 future `tusk setup --verify` runs can reuse it. Read the existing file first (if it
 exists) to preserve other entries (like `simple_test`).
 
-If `.tusk/verify-cache.json` does not exist, create it.
+If `.tusk/setup/verify-cache.json` does not exist, create it.
 
 Format:
 
@@ -48,7 +48,7 @@ Format:
 }
 ```
 
-Write the updated JSON back to `.tusk/verify-cache.json`.
+Write the updated JSON back to `.tusk/setup/verify-cache.json`.
 
 Call transition_phase with:
 

--- a/internal/agent/prompts/phase_create_config.md
+++ b/internal/agent/prompts/phase_create_config.md
@@ -76,13 +76,14 @@ Common config mistakes to avoid:
 After creating the config file, update the project's `.gitignore` to exclude Tusk artifacts that shouldn't be committed:
 
 1. Use `read_file` to check if `.gitignore` exists and read its contents
-2. Check if Tusk entries (`.tusk/results`, `.tusk/logs`) are already present
+2. Check if Tusk entries (`.tusk/results`, `.tusk/logs`, `.tusk/setup`) are already present
 3. If missing, append the following block to `.gitignore`:
 
 ```text
 # Tusk Drift
 .tusk/results
 .tusk/logs
+.tusk/setup
 ```
 
 - If `.gitignore` doesn't exist, create it with just the Tusk entries

--- a/internal/agent/prompts/phase_simple_test.md
+++ b/internal/agent/prompts/phase_simple_test.md
@@ -52,11 +52,11 @@ If it fails:
 
 ### Step 5: Save to Verify Cache
 
-If the test passed, save the endpoint info used to `.tusk/verify-cache.json` so that
+If the test passed, save the endpoint info used to `.tusk/setup/verify-cache.json` so that
 future `tusk setup --verify` runs can reuse it. Read the existing file first (if it
 exists) to preserve other entries (like `complex_test`).
 
-If `.tusk/verify-cache.json` does not exist, create it.
+If `.tusk/setup/verify-cache.json` does not exist, create it.
 
 Format:
 
@@ -71,7 +71,7 @@ Format:
 }
 ```
 
-Write the updated JSON back to `.tusk/verify-cache.json`.
+Write the updated JSON back to `.tusk/setup/verify-cache.json`.
 
 When a simple test passes, call transition_phase with:
 

--- a/internal/agent/prompts/phase_summary.md
+++ b/internal/agent/prompts/phase_summary.md
@@ -19,6 +19,6 @@ Generate a final report documenting:
    - Any important observations
 
 IMPORTANT: First output the FULL report content as text in your response so the user can read it in the terminal.
-Then save the same report to .tusk/SETUP_REPORT.md using write_file.
+Then save the same report to .tusk/setup/SETUP_REPORT.md using write_file.
 
 After saving the report, call transition_phase to complete.

--- a/internal/agent/prompts/phase_verify_complex_test.md
+++ b/internal/agent/prompts/phase_verify_complex_test.md
@@ -4,7 +4,7 @@ Test an endpoint with external calls if one was previously cached or can be foun
 
 ### Step 1: Determine Endpoint
 
-Read `.tusk/verify-cache.json`. If a `complex_test` entry exists, use that endpoint's
+Read `.tusk/setup/verify-cache.json`. If a `complex_test` entry exists, use that endpoint's
 URL, method, headers, and body.
 
 If no cache entry exists, look through the codebase (using grep) for an endpoint that
@@ -22,6 +22,7 @@ The Tusk Drift SDK excludes "text/html" traces.
 ### Step 2: Record and Replay
 
 Follow the same process as the simple test:
+
 1. Start service with env: {"TUSK_DRIFT_MODE": "RECORD"}
 2. Wait for the service to be ready
 3. Make the HTTP request to the endpoint
@@ -32,7 +33,7 @@ Follow the same process as the simple test:
 
 ### Step 3: Save to Cache
 
-If the test passed, update `.tusk/verify-cache.json` with the `complex_test` entry.
+If the test passed, update `.tusk/setup/verify-cache.json` with the `complex_test` entry.
 Read the existing file first to preserve the `simple_test` entry.
 
 ### Transition
@@ -40,6 +41,7 @@ Read the existing file first to preserve the `simple_test` entry.
 This phase is optional - if it fails but simple test passed, that is acceptable.
 
 Call transition_phase with:
+
 ```json
 {
   "results": {

--- a/internal/agent/prompts/phase_verify_setup.md
+++ b/internal/agent/prompts/phase_verify_setup.md
@@ -10,6 +10,7 @@ If validation fails, report the error and call transition_phase with failure not
 ### Step 2: Read Current Recording Config
 
 Read `.tusk/config.yaml` and extract the current values:
+
 - Under `recording`: `sampling_rate`, `export_spans`, `enable_env_var_recording`
 - Under `service`: `id` (if present)
 - Under `service`: `port`
@@ -21,6 +22,7 @@ Store the recording values as the originals to restore later.
 ### Step 3: Override Recording Config
 
 Use `cloud_save_config` to set:
+
 - `sampling_rate`: 1 (record everything for verification)
 - `export_spans`: false (keep traces local during verification)
 - `enable_env_var_recording`: keep whatever it currently is
@@ -34,10 +36,11 @@ This ensures we start with a clean slate for verification.
 
 ### Step 5: Check for Verify Cache
 
-Read `.tusk/verify-cache.json` if it exists. If found, this contains cached endpoint
+Read `.tusk/setup/verify-cache.json` if it exists. If found, this contains cached endpoint
 information from a previous successful verify or setup run.
 
 Call transition_phase with:
+
 ```json
 {
   "results": {

--- a/internal/agent/prompts/phase_verify_simple_test.md
+++ b/internal/agent/prompts/phase_verify_simple_test.md
@@ -4,7 +4,7 @@ Record and replay a simple health check to verify the setup works.
 
 ### Step 1: Determine Endpoint
 
-Read `.tusk/verify-cache.json` if it exists. If it contains a `simple_test` entry,
+Read `.tusk/setup/verify-cache.json` if it exists. If it contains a `simple_test` entry,
 use that endpoint's URL, method, headers, and body.
 
 If no cache exists, use the `health_endpoint` and `port` from the current state
@@ -31,15 +31,17 @@ If no traces appear, this is a verification failure.
 
 Run tusk_run to replay the trace.
 If it fails:
+
 - Run with `debug: true` once more
 - If still failing, mark as failed
 
 ### Step 5: Save to Cache
 
-If the test passed, update `.tusk/verify-cache.json` with the endpoint info used.
+If the test passed, update `.tusk/setup/verify-cache.json` with the endpoint info used.
 Read the existing file first (if it exists) to preserve other entries (like `complex_test`).
 
 Format:
+
 ```json
 {
   "simple_test": {
@@ -51,11 +53,12 @@ Format:
 }
 ```
 
-Write the updated JSON back to `.tusk/verify-cache.json`.
+Write the updated JSON back to `.tusk/setup/verify-cache.json`.
 
 ### Transition
 
 Call transition_phase with:
+
 ```json
 {
   "results": {

--- a/internal/agent/tools/abort.go
+++ b/internal/agent/tools/abort.go
@@ -58,7 +58,7 @@ func ResetPhaseProgress(workDir string) func(json.RawMessage) (string, error) {
 			return "", err
 		}
 
-		progressPath := filepath.Clean(filepath.Join(workDir, ".tusk", "PROGRESS.md"))
+		progressPath := filepath.Clean(filepath.Join(workDir, ".tusk", "setup", "PROGRESS.md"))
 
 		content, err := os.ReadFile(progressPath)
 		if err != nil {

--- a/internal/agent/tui.go
+++ b/internal/agent/tui.go
@@ -671,7 +671,7 @@ func (m *TUIModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.currentTool = ""
 		m.addLog("spacing", "", "")
 		m.addLog("success", "🎉 Setup complete!", "")
-		m.addLog("dim", "   Check .tusk/SETUP_REPORT.md for details.", "")
+		m.addLog("dim", "   Check .tusk/setup/SETUP_REPORT.md for details.", "")
 		m.addLog("spacing", "", "")
 		m.addLog("plain", "───────────────────────────────────────────────────────────", "")
 		m.addLog("spacing", "", "")
@@ -1757,20 +1757,10 @@ func (m *TUIModel) SendCompleted(program *tea.Program, workDir string) {
 	// Check which cleanup files exist
 	var removableFiles []string
 
-	filesToCheck := []struct {
-		filename    string
-		description string
-	}{
-		{"PROGRESS.md", "PROGRESS.md - Setup progress tracking"},
-		{"SETUP_REPORT.md", "SETUP_REPORT.md - Setup summary and test results"},
-		{"CLOUD_SETUP_REPORT.md", "CLOUD_SETUP_REPORT.md - Cloud setup summary"},
-	}
-
-	tuskDir := filepath.Join(workDir, ".tusk")
-	for _, f := range filesToCheck {
-		if _, err := os.Stat(filepath.Join(tuskDir, f.filename)); err == nil {
-			removableFiles = append(removableFiles, f.description)
-		}
+	// Check if the entire .tusk/setup/ directory exists and has files
+	setupDir := filepath.Join(workDir, ".tusk", "setup")
+	if _, err := os.Stat(setupDir); err == nil {
+		removableFiles = append(removableFiles, ".tusk/setup/ - Setup progress, reports, and cache")
 	}
 
 	program.Send(completedMsg{removableFiles: removableFiles})

--- a/internal/agent/types.go
+++ b/internal/agent/types.go
@@ -143,7 +143,7 @@ type Config struct {
 	MaxTokens       int
 	WorkDir         string
 	SkipPermissions bool   // Skip permission prompts for consequential actions
-	DisableProgress bool   // Don't save or resume from PROGRESS.md
+	DisableProgress bool   // Don't save or resume from .tusk/setup/PROGRESS.md
 	SkipToCloud     bool   // Skip local setup and go directly to cloud setup (for testing)
 	PrintMode       bool   // Headless mode - no TUI, stream to stdout
 	OutputLogs      bool   // Output all logs to a file in .tusk/logs/

--- a/internal/agent/ui_headless.go
+++ b/internal/agent/ui_headless.go
@@ -164,7 +164,7 @@ func (u *HeadlessUI) FatalError(err error) {
 func (u *HeadlessUI) Completed(workDir string) {
 	fmt.Println()
 	fmt.Println(headlessSuccessStyle.Render("🎉 Setup complete!"))
-	fmt.Println(headlessDimStyle.Render("   Check .tusk/SETUP_REPORT.md for details."))
+	fmt.Println(headlessDimStyle.Render("   Check .tusk/setup/SETUP_REPORT.md for details."))
 }
 
 // EligibilityCompleted displays eligibility check completion message


### PR DESCRIPTION
### Summary

Save all setup agent state/artifacts to `.tusk/setup`. Helps make the user's repo cleaner and easier to gitignore.

### Changes

- Changed default progress file path from `PROGRESS.md` to `.tusk/setup/PROGRESS.md`.
- Updated references in documentation and code to reflect the new setup directory structure.
- Added `.tusk/setup` to `.gitignore` recommendations in `README.md`.
- Ensured all related prompts and logs point to the new setup directory for consistency.