### PR TITLE
fix: avoid schema fallback collisions for sqlalchemy query mocks

### DIFF
--- a/internal/runner/mock_matcher.go
+++ b/internal/runner/mock_matcher.go
@@ -66,7 +66,7 @@ func NewMockMatcher(server *Server) *MockMatcher {
 }
 
 func shouldSkipSchemaFallbackMatching(req *core.GetMockRequest) bool {
-	// Guardrail: for DB spans like psycopg2.query, schema-based matching (priorities 7-10)
+	// Guardrail: for DB query spans like psycopg2.query/sqlalchemy.query, schema-based matching (priorities 7-10)
 	// is extremely high collision risk because many different SQL statements share the same schema:
 	// {"query": string, "parameters": array}. Similarity scoring can then pick an incorrect span
 	// and return a wrong row shape/value, which is worse than "no mock found".
@@ -82,7 +82,7 @@ func shouldSkipSchemaFallbackMatching(req *core.GetMockRequest) bool {
 	}
 
 	pkg := strings.ToLower(req.OutboundSpan.PackageName)
-	if pkg != "psycopg2" && pkg != "psycopg" {
+	if pkg != "psycopg2" && pkg != "psycopg" && pkg != "sqlalchemy" {
 		return false
 	}
 


### PR DESCRIPTION
### Summary

Extend the query-matching safety guardrail to SQLAlchemy DB spans so replay fails fast on ambiguous matches instead of returning incorrect mock data.

### Changes

- Update `shouldSkipSchemaFallbackMatching` in `internal/runner/mock_matcher.go` to treat `packageName=sqlalchemy` query spans the same as `psycopg2`/`psycopg` query spans
- Keep priorities 1-6 (exact/reduced input value hash matching) and skip schema/similarity fallback (priorities 7-10) for non-pre-app-start SQLAlchemy query requests
- Add `TestFindBestMatchWithTracePriority_SqlAlchemyQuery_DoesNotUseSchemaFallback` in `internal/runner/mock_matcher_test.go`
- Preserve existing behavior for pre-app-start spans and non-query/non-DB packages

### Context

During FastAPI + SQLAlchemy replay validation, schema-based fallback could select a wrong SQL mock for generic DB query schemas (`query` + `parameters`). This change aligns SQLAlchemy query matching with existing psycopg protections and reduces false-positive matches that surface as downstream 404/500 deviations.
