### PR TITLE
fix(drift): close active connections on shutdown to prevent Ctrl+C hang

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -185,6 +185,13 @@ func setupSignalHandling() {
 		go func() {
 			sig := <-c
 			fmt.Fprintf(os.Stderr, "Received %s signal, cleaning up\n", sig)
+
+			go func() {
+				<-c
+				fmt.Fprintf(os.Stderr, "\nForce exit\n")
+				os.Exit(2)
+			}()
+
 			runCleanup()
 			os.Exit(1)
 		}()

--- a/internal/runner/server.go
+++ b/internal/runner/server.go
@@ -632,6 +632,10 @@ func (ms *Server) acceptConnections() {
 				continue
 			}
 
+			ms.activeConnsMu.Lock()
+			ms.activeConns[conn] = struct{}{}
+			ms.activeConnsMu.Unlock()
+
 			ms.wg.Add(1)
 			go ms.handleConnection(conn)
 		}
@@ -641,10 +645,6 @@ func (ms *Server) acceptConnections() {
 // handleConnection processes a single SDK connection
 func (ms *Server) handleConnection(conn net.Conn) {
 	defer ms.wg.Done()
-
-	ms.activeConnsMu.Lock()
-	ms.activeConns[conn] = struct{}{}
-	ms.activeConnsMu.Unlock()
 
 	defer func() {
 		ms.activeConnsMu.Lock()

--- a/internal/runner/server.go
+++ b/internal/runner/server.go
@@ -68,6 +68,8 @@ type Server struct {
 	wg                     sync.WaitGroup
 	mu                     sync.RWMutex
 	connWriteMutex         sync.Mutex
+	activeConns            map[net.Conn]struct{}
+	activeConnsMu          sync.Mutex
 	sdkVersion             string
 	sdkConnected           bool
 	sdkConnectedChan       chan struct{}
@@ -176,6 +178,7 @@ func NewServer(serviceID string, cfg *config.ServiceConfig) (*Server, error) {
 		communicationType:  commType,
 		tcpPort:            cfg.Communication.TCPPort,
 		pendingRequests:    make(map[string]chan *core.SDKMessage),
+		activeConns:        make(map[net.Conn]struct{}),
 	}
 
 	return server, nil
@@ -308,6 +311,13 @@ func (ms *Server) Stop() error {
 	if ms.listener != nil {
 		_ = ms.listener.Close()
 	}
+
+	// Close all active connections so blocked reads unblock
+	ms.activeConnsMu.Lock()
+	for conn := range ms.activeConns {
+		_ = conn.Close()
+	}
+	ms.activeConnsMu.Unlock()
 
 	// Clean up socket file only for Unix sockets
 	if ms.communicationType == CommunicationUnix {
@@ -631,7 +641,17 @@ func (ms *Server) acceptConnections() {
 // handleConnection processes a single SDK connection
 func (ms *Server) handleConnection(conn net.Conn) {
 	defer ms.wg.Done()
-	defer func() { _ = conn.Close() }()
+
+	ms.activeConnsMu.Lock()
+	ms.activeConns[conn] = struct{}{}
+	ms.activeConnsMu.Unlock()
+
+	defer func() {
+		ms.activeConnsMu.Lock()
+		delete(ms.activeConns, conn)
+		ms.activeConnsMu.Unlock()
+		_ = conn.Close()
+	}()
 
 	for {
 		// Read message length (4 bytes)

--- a/internal/runner/server_test.go
+++ b/internal/runner/server_test.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +16,54 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+func TestServerStopClosesActiveConnections(t *testing.T) {
+	config.Invalidate()
+
+	testServiceConfig := &config.ServiceConfig{
+		ID:   "test-stop-conns",
+		Port: 3000,
+		Start: config.StartConfig{
+			Command: "node server.js",
+		},
+		Communication: config.CommunicationConfig{
+			Type:    "tcp",
+			TCPPort: 0, // let OS pick a port
+		},
+	}
+
+	server, err := NewServer("test-stop-conns", testServiceConfig)
+	require.NoError(t, err)
+
+	err = server.Start()
+	require.NoError(t, err)
+
+	// Connect a client that stays idle (simulates SDK connection blocked on read)
+	actualPort := server.listener.Addr().(*net.TCPAddr).Port
+	conn, err := net.Dial("tcp", fmt.Sprintf("127.0.0.1:%d", actualPort))
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	// Wait for the server to accept and track the connection
+	require.Eventually(t, func() bool {
+		server.activeConnsMu.Lock()
+		defer server.activeConnsMu.Unlock()
+		return len(server.activeConns) > 0
+	}, 2*time.Second, 5*time.Millisecond)
+
+	// Stop should return promptly — not hang on wg.Wait()
+	done := make(chan error, 1)
+	go func() {
+		done <- server.Stop()
+	}()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("server.Stop() hung — active connections were not closed")
+	}
+}
 
 func TestIsVersionCompatible(t *testing.T) {
 	tcs := []struct {

--- a/internal/tui/test_executor.go
+++ b/internal/tui/test_executor.go
@@ -53,7 +53,7 @@ type testExecutorModel struct {
 	actualLeftPanelWidth int // For accurate mouse coordinates
 
 	// Control flags
-	serverStarted bool
+	serverStarted  bool
 	serviceStarted bool
 
 	// Environment grouping

--- a/internal/tui/test_executor.go
+++ b/internal/tui/test_executor.go
@@ -467,7 +467,6 @@ func (m *testExecutorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.sizeWarning.Dismiss()
 				return m, nil
 			case "q", "ctrl+c":
-				m.forceExitAfter(5 * time.Second)
 				m.cleanup()
 				return m, tea.Quit
 			}
@@ -883,7 +882,6 @@ func (m *testExecutorModel) handleTableNavigation(msg tea.KeyMsg) (tea.Model, te
 		return m, m.logPanel.CopyAllLogs()
 
 	case "q", "ctrl+c":
-		m.forceExitAfter(5 * time.Second)
 		m.cleanup()
 		return m, tea.Quit
 	}
@@ -1279,19 +1277,6 @@ func (m *testExecutorModel) hasAnyDeviations() bool {
 		}
 	}
 	return false
-}
-
-// forceExitAfter spawns a goroutine that force-exits the process if cleanup
-// doesn't complete within the given duration. In the TUI, Bubble Tea's raw
-// terminal mode means Ctrl+C is a key event, not an OS signal, so the event
-// loop is blocked while cleanup runs synchronously. This is the only way to
-// guarantee the process won't hang.
-func (m *testExecutorModel) forceExitAfter(d time.Duration) {
-	go func() {
-		time.Sleep(d)
-		fmt.Fprintf(os.Stderr, "\nCleanup timed out, force exiting\n")
-		os.Exit(2)
-	}()
 }
 
 func (m *testExecutorModel) cleanup() {

--- a/internal/tui/test_executor.go
+++ b/internal/tui/test_executor.go
@@ -53,7 +53,7 @@ type testExecutorModel struct {
 	actualLeftPanelWidth int // For accurate mouse coordinates
 
 	// Control flags
-	serverStarted  bool
+	serverStarted bool
 	serviceStarted bool
 
 	// Environment grouping
@@ -467,6 +467,7 @@ func (m *testExecutorModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.sizeWarning.Dismiss()
 				return m, nil
 			case "q", "ctrl+c":
+				m.forceExitAfter(5 * time.Second)
 				m.cleanup()
 				return m, tea.Quit
 			}
@@ -882,6 +883,7 @@ func (m *testExecutorModel) handleTableNavigation(msg tea.KeyMsg) (tea.Model, te
 		return m, m.logPanel.CopyAllLogs()
 
 	case "q", "ctrl+c":
+		m.forceExitAfter(5 * time.Second)
 		m.cleanup()
 		return m, tea.Quit
 	}
@@ -1277,6 +1279,19 @@ func (m *testExecutorModel) hasAnyDeviations() bool {
 		}
 	}
 	return false
+}
+
+// forceExitAfter spawns a goroutine that force-exits the process if cleanup
+// doesn't complete within the given duration. In the TUI, Bubble Tea's raw
+// terminal mode means Ctrl+C is a key event, not an OS signal, so the event
+// loop is blocked while cleanup runs synchronously. This is the only way to
+// guarantee the process won't hang.
+func (m *testExecutorModel) forceExitAfter(d time.Duration) {
+	go func() {
+		time.Sleep(d)
+		fmt.Fprintf(os.Stderr, "\nCleanup timed out, force exiting\n")
+		os.Exit(2)
+	}()
 }
 
 func (m *testExecutorModel) cleanup() {


### PR DESCRIPTION
`tusk drift run --print` hangs on Ctrl+C when the mock server has an active SDK connection.

### Root cause

`server.Stop()` calls `ms.wg.Wait()`, which blocks until all `handleConnection` goroutines finish. Those goroutines are stuck on `io.ReadFull(conn, ...)` — a blocking read with no deadline. Closing the listener prevents new connections but doesn't close existing ones, so `io.ReadFull` never returns and the process hangs indefinitely.

### Changes

- Track active connections in a map and close them all in `Stop()` before `wg.Wait()`, so blocked reads return immediately with an error
- Add force-exit on second Ctrl+C as a safety net — if cleanup itself hangs for any reason, users aren't stuck
- Add `TestServerStopClosesActiveConnections` — verified it fails without the fix (hangs for 2s then times out) and passes with it
