### PR TITLE
feat: skip UV_ environment variables during replay

### DIFF
--- a/internal/runner/replay_env.go
+++ b/internal/runner/replay_env.go
@@ -28,6 +28,7 @@ var replayProcessEnvVarPrefixesToSkip = []string{
 	"RBENV_",
 	"SDKMAN_",
 	"VOLTA_",
+	"UV_",
 }
 
 func shouldSkipReplayEnvVarForProcess(key string) bool {


### PR DESCRIPTION
### Summary
Adds the `UV_` prefix to the list of environment variable prefixes that are filtered out during replay. [UV](https://github.com/astral-sh/uv) is a Python package/project manager whose environment variables (e.g. `UV_CACHE_DIR`, `UV_PYTHON`, `UV_PYTHON_PREFERENCE`) are host-specific and should not be carried over from recorded environment snapshots.
### Changes
- Added `"UV_"` to `replayProcessEnvVarPrefixesToSkip` in `internal/runner/replay_env.go`, alongside other version/runtime manager prefixes like `PYENV_`, `NVM_`, `VOLTA_`, etc.
